### PR TITLE
Executable .jar file to run as a service

### DIFF
--- a/EXAMPLE-grouse.service
+++ b/EXAMPLE-grouse.service
@@ -1,0 +1,17 @@
+# Example Systemd service definition for KDRS grouse (a.k.a Kravspec)
+
+# Adjest the executable path and other attributes as required
+# Install in /etc/systemd/system (On Ubunu, anyway) as grouse.service
+# User and group should be root, mode 0600.
+
+[Unit]
+Description=grouse
+After=syslog.target
+
+[Service]
+User=grouse
+ExecStart=/srv/grouse/latest/target/kravspec-1.0-SNAPSHOT.jar
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/EXAMPLE-kravspec-1.0-SNAPSHOT.conf
+++ b/EXAMPLE-kravspec-1.0-SNAPSHOT.conf
@@ -1,0 +1,12 @@
+# Example configuration file for kravspec-1.0-SNAPSOT.jar running as a service.
+
+# It goes in the "target" directory along with the jar file.
+# The basename MUST match the basename of the jar file, the suffix must be conf.
+
+# Adjust the DB URL, username and password as appropriate.
+
+# This file assuemes that the default profile (application.yml) in the jar
+# is for MySQL. If not, you need to set the active profile here as well.
+# (Or replace these arguments with whatever you need.)
+
+RUN_ARGS="--spring.datasource.url=jdbc:mysql://localhost:3306/grouse?useSSL=false --spring.datasource.username=DB-USER-MAME --spring.datasource.password=DB-PASSWORD"

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,9 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+                <executable>true</executable>
+        </configuration>
         <version>2.0.0.RELEASE</version>
       </plugin>
 


### PR DESCRIPTION
Modified pom.xml to build the backend kravspec -<version>.jar  so that it can be executed directly.

Also added examples of a couple of files that are needed to run the backend as a service under systemd.
This stuff works on Ubuntu 16.04 on Ubuntu.