### PR TITLE
Introduce asciidoc and pandoc for file format conversions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,11 +1,10 @@
 # Grouse
 Grouse consists of both a REST-api and a web-based GUI.
 
-
 Grouse is a Java application so you need both maven and Java.
 Depending on which route you pick you might also need to install other
 dependencies.  The project is developed on a Linux machine with Apache Maven
-3.2.1 and Java 1.8. Please make sure both of these are installed before you
+3.6.0 and Java 11. Please make sure both of these are installed before you
 attempt to run the project. You can verify your versions with:
 
     mvn --version
@@ -51,6 +50,13 @@ successful
  	
  	Started GrouseApplication in 15.489 seconds (JVM running for 19.948)
 
+## Third party requirements
+
+Grouse requires the availability of the asciidoc and pandoc programs to generate the
+requirements document. The command grouse uses to generate the requirements document is:
+
+    asciidoctor --backend docbook --out-file - requirements.adoc |pandoc --from docbook --to odt  --output requirements.odt
+     
 ## API
 
 You should be able to see which REST calls are available from the logging 

--- a/TEST.md
+++ b/TEST.md
@@ -1506,3 +1506,43 @@ This results in the following payload:
         }
       }
     }
+
+
+## Downloading a document
+
+### Identifying supported formats
+
+Grouse can render the requirements document in various formats. The formats that grouse has tested it can render can be found by looking for a  supported-formats rel/href pair. This can be found either of the application root:
+
+    curl -X GET http://localhost:9294/grouse/ -H 'Authorization: Bearer 9536be09-7851-40fc-879f-6333256071a5'
+
+or when getting a project: 
+    
+    curl -X GET http://localhost:9294/grouse/project/e2e9643c-1a30-4eb5-b8e5-ba1dd0245397 -H 'Authorization: Bearer 9536be09-7851-40fc-879f-6333256071a5'
+    
+This will produce the following JSON:    
+     
+    {
+      "supportedFormats": {
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+        "application/vnd.oasis.opendocument.text": "odt",
+        "text/html": "html",
+        "application/pdf": "pdf",
+        "application/rtf": "rtf",
+        "text/asciidoc": "adoc",
+        "text/markdown": "md"
+      },
+      "_links": {
+        "self": {
+          "href": "http://localhost:9294/grouse/document/supported-formats"
+        }
+      }
+    }
+
+Other file formats can be added or removed using the _supported.formats_ property in _application.yml_.
+
+Grouse generates the requirements document at the same time the document is downloaded. To download the requirements document in a given format use the following command:
+
+    curl --output file.docx -v -H 'Accept: application/vnd.openxmlformats-officedocument.wordprocessingml.document' -X GET http://localhost:9294/grouse/project/37d6ea88-348f-4dea-a75e-e83a6bd3cc05/document -H 'Authorization: Bearer 9536be09-7851-40fc-879f-6333256071a5'  
+
+For the basic Noark template it takes about 3 seconds to generate and download the requirements document in each of the supported formats.

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <java.version>11</java.version>
     <spring-security-oauth2.version>2.3.6.RELEASE</spring-security-oauth2.version>
     <lombok.version>1.18.12</lombok.version>
+    <asciidoc.version>1.5.5</asciidoc.version>
     <!-- commons and utils -->
     <commons-lang3.version>3.4</commons-lang3.version>
     <jquery.version>3.2.1</jquery.version>
@@ -211,6 +212,11 @@
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20180130</version>
+    </dependency>
+    <dependency>
+      <groupId>org.asciidoctor</groupId>
+      <artifactId>asciidoctorj</artifactId>
+      <version>${asciidoc.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
     <java.version>11</java.version>
     <spring-security-oauth2.version>2.3.6.RELEASE</spring-security-oauth2.version>
     <lombok.version>1.18.12</lombok.version>
-    <asciidoc.version>1.6.0</asciidoc.version>
     <spring-boot-configuration-processor.version>2.2.6.RELEASE</spring-boot-configuration-processor.version>
     <!-- commons and utils -->
     <commons-lang3.version>3.4</commons-lang3.version>
@@ -213,11 +212,6 @@
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20180130</version>
-    </dependency>
-    <dependency>
-      <groupId>org.asciidoctor</groupId>
-      <artifactId>asciidoctorj</artifactId>
-      <version>${asciidoc.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,8 @@
     <java.version>11</java.version>
     <spring-security-oauth2.version>2.3.6.RELEASE</spring-security-oauth2.version>
     <lombok.version>1.18.12</lombok.version>
-    <asciidoc.version>1.5.5</asciidoc.version>
+    <asciidoc.version>1.6.0</asciidoc.version>
+    <spring-boot-configuration-processor.version>2.2.6.RELEASE</spring-boot-configuration-processor.version>
     <!-- commons and utils -->
     <commons-lang3.version>3.4</commons-lang3.version>
     <jquery.version>3.2.1</jquery.version>
@@ -217,6 +218,13 @@
       <groupId>org.asciidoctor</groupId>
       <artifactId>asciidoctorj</artifactId>
       <version>${asciidoc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <version>${spring-boot-configuration-processor.version}</version>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/src/main/java/no/kdrs/grouse/GrouseEventListener.java
+++ b/src/main/java/no/kdrs/grouse/GrouseEventListener.java
@@ -5,8 +5,6 @@ import no.kdrs.grouse.model.AccessControl;
 import no.kdrs.grouse.model.Project;
 import no.kdrs.grouse.service.ACLService;
 import no.kdrs.grouse.utils.exception.InternalException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.core.context.SecurityContext;
@@ -20,23 +18,17 @@ import static no.kdrs.grouse.utils.Constants.PROJECT;
 @Transactional
 public class GrouseEventListener {
 
-    private static final Logger logger =
-            LoggerFactory.getLogger(GrouseEventListener.class);
-
     @Autowired
     private ACLService aclService;
-
 
     @EventListener
     public void handleCreationEvent(GrouseCreationEvent event) {
         Project project = event.getProject();
-        logger.info("Creating a object of type Project");
         AccessControl accessControl = new AccessControl();
         accessControl.setObjectType(PROJECT);
         accessControl.setGrouseUser(getUser());
         accessControl.setGrouseObject(project.getProjectId());
         aclService.createACLEntryOnCreate(project.getProjectId(), accessControl);
-
     }
 
     public String getUser() {

--- a/src/main/java/no/kdrs/grouse/assemblers/APIAssembler.java
+++ b/src/main/java/no/kdrs/grouse/assemblers/APIAssembler.java
@@ -58,6 +58,9 @@ public class APIAssembler
             linksAPIDetail.add(linkTo(methodOn(ProjectController.class)
                     .getProjectsForUser(null))
                     .withRel(REL_PROJECT_LIST));
+            linksAPIDetail.add(linkTo(methodOn(DocumentController.class)
+                    .getSupportedFileFormats())
+                    .withRel(SUPPORTED_FORMATS));
             linksAPIDetail.add(linkTo(methodOn(TemplateController.class)
                     .getTemplates(null))
                     .withRel(REL_TEMPLATE_LIST));

--- a/src/main/java/no/kdrs/grouse/assemblers/ProjectAssembler.java
+++ b/src/main/java/no/kdrs/grouse/assemblers/ProjectAssembler.java
@@ -39,7 +39,7 @@ public class ProjectAssembler
                         project.getProjectId()))
                 .withRel(FUNCTIONALITY));
         linksProject.add(linkTo(methodOn(DocumentController.class)
-                .downloadProjectDocument(project.getProjectId()))
+                .downloadProjectDocument(null, project.getProjectId()))
                 .withRel(DOCUMENT));
         linksProject.add(linkTo(methodOn(ProjectController.class)
                 .shareProject(project.getProjectId(),
@@ -68,7 +68,7 @@ public class ProjectAssembler
                                     null, project.getProjectId()))
                             .withRel(FUNCTIONALITY));
             project.add(linkTo(methodOn(DocumentController.class)
-                    .downloadProjectDocument(project.getProjectId()))
+                    .downloadProjectDocument(null, project.getProjectId()))
                     .withRel(DOCUMENT));
             project.add(linkTo(methodOn(ProjectController.class)
                     .shareProject(project.getProjectId(),

--- a/src/main/java/no/kdrs/grouse/assemblers/ProjectAssembler.java
+++ b/src/main/java/no/kdrs/grouse/assemblers/ProjectAssembler.java
@@ -41,6 +41,9 @@ public class ProjectAssembler
         linksProject.add(linkTo(methodOn(DocumentController.class)
                 .downloadProjectDocument(null, project.getProjectId()))
                 .withRel(DOCUMENT));
+        linksProject.add(linkTo(methodOn(DocumentController.class)
+                .getSupportedFileFormats())
+                .withRel(SUPPORTED_FORMATS));
         linksProject.add(linkTo(methodOn(ProjectController.class)
                 .shareProject(project.getProjectId(),
                         USER_EMAIL_ADDRESS))
@@ -70,6 +73,9 @@ public class ProjectAssembler
             project.add(linkTo(methodOn(DocumentController.class)
                     .downloadProjectDocument(null, project.getProjectId()))
                     .withRel(DOCUMENT));
+            project.add(linkTo(methodOn(DocumentController.class)
+                    .getSupportedFileFormats())
+                    .withRel(SUPPORTED_FORMATS));
             project.add(linkTo(methodOn(ProjectController.class)
                     .shareProject(project.getProjectId(),
                             "{user email address}"))

--- a/src/main/java/no/kdrs/grouse/assemblers/SupportedFormatAssembler.java
+++ b/src/main/java/no/kdrs/grouse/assemblers/SupportedFormatAssembler.java
@@ -1,0 +1,48 @@
+package no.kdrs.grouse.assemblers;
+
+import no.kdrs.grouse.controller.DocumentController;
+import no.kdrs.grouse.model.SupportedFormats;
+import no.kdrs.grouse.model.links.LinksSupportedFormats;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Component
+public class SupportedFormatAssembler
+        extends RepresentationModelAssemblerSupport<
+        SupportedFormats, LinksSupportedFormats> {
+
+    public SupportedFormatAssembler() {
+        super(DocumentController.class, LinksSupportedFormats.class);
+    }
+
+    @Override
+    public LinksSupportedFormats toModel(SupportedFormats supportedFormats) {
+        LinksSupportedFormats linksSupportedFormats = instantiateModel(supportedFormats);
+        linksSupportedFormats.setSupportedFormats(supportedFormats);
+        linksSupportedFormats.add(linkTo(methodOn(DocumentController.class)
+                .getSupportedFileFormats())
+                .withSelfRel());
+        return linksSupportedFormats;
+    }
+
+    @Override
+    public CollectionModel<LinksSupportedFormats> toCollectionModel(
+            Iterable<? extends SupportedFormats> supportedFormats) {
+        CollectionModel<LinksSupportedFormats> linksSupportedFormats =
+                super.toCollectionModel(supportedFormats);
+
+        linksSupportedFormats.forEach(supportedFormat -> {
+            supportedFormat
+                    .add(linkTo(methodOn(DocumentController.class)
+                            .getSupportedFileFormats())
+                            .withSelfRel());
+        });
+        return linksSupportedFormats;
+    }
+}

--- a/src/main/java/no/kdrs/grouse/controller/DocumentController.java
+++ b/src/main/java/no/kdrs/grouse/controller/DocumentController.java
@@ -64,7 +64,7 @@ public class DocumentController {
         Project project = projectService.updateProjectFinalised(projectId);
         // We should revisit this in case there is a need to undo setting the
         // document to finalised if the document cannot be created.
-        documentService.createDocument(project);
+        documentService.createAsciiDocument(project);
         return commonController.addProjectLinks(project, CREATED);
     }
 

--- a/src/main/java/no/kdrs/grouse/controller/DocumentController.java
+++ b/src/main/java/no/kdrs/grouse/controller/DocumentController.java
@@ -2,8 +2,10 @@
 package no.kdrs.grouse.controller;
 
 import no.kdrs.grouse.model.Project;
+import no.kdrs.grouse.model.SupportedFormats;
 import no.kdrs.grouse.model.Template;
 import no.kdrs.grouse.model.links.LinksProject;
+import no.kdrs.grouse.model.links.LinksSupportedFormats;
 import no.kdrs.grouse.service.interfaces.IDocumentService;
 import no.kdrs.grouse.service.interfaces.IProjectService;
 import no.kdrs.grouse.service.interfaces.ITemplateService;
@@ -12,21 +14,23 @@ import no.kdrs.grouse.utils.exception.InternalException;
 import org.apache.tomcat.util.http.fileupload.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static no.kdrs.grouse.utils.Constants.*;
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 /**
  * DocumentController that has two tasks.
@@ -46,6 +50,9 @@ public class DocumentController {
     private ITemplateService templateService;
     private CommonController commonController;
 
+    @Value("#{${supported.formats}}")
+    private Map<String, String> supportedFormats;
+
     public DocumentController(IDocumentService documentService,
                               IProjectService projectService,
                               ITemplateService templateService,
@@ -64,29 +71,41 @@ public class DocumentController {
         Project project = projectService.updateProjectFinalised(projectId);
         // We should revisit this in case there is a need to undo setting the
         // document to finalised if the document cannot be created.
-        documentService.createAsciiDocument(project, "docx");
+        documentService.createAsciiDocument(projectId, "docx");
         return commonController.addProjectLinks(project, CREATED);
+    }
+
+    @GetMapping(SLASH + DOCUMENT + SLASH + SUPPORTED_FORMATS)
+    public ResponseEntity<LinksSupportedFormats> getSupportedFileFormats() {
+        return commonController.addSupportedFormatsLinks(
+                new SupportedFormats(supportedFormats), OK);
     }
 
     @GetMapping(SLASH + PROJECT + SLASH + PROJECT_NUMBER_PARAMETER + SLASH +
             DOCUMENT)
     public HttpEntity<byte[]> downloadProjectDocument(
+            HttpRequest request,
             @PathVariable(PROJECT_NUMBER) UUID projectId) {
-        Project project = projectService.findById(projectId);
-        if (null == project.getFileNameInternal()) {
-            throw new InternalException("Can't download document, no filename" +
-                    "for project " + projectId);
-        }
-        var file = Paths.get(project.getFileNameInternal());
 
-        try {
-            return getDocument(file, project.getFileName());
-        } catch (IOException e) {
-            String errorMessage = "Problem getting file for project (" +
-                    projectId + ")";
-            logger.error(errorMessage);
-            throw new InternalException(errorMessage);
+        List<MediaType> accepts = request.getHeaders().getAccept();
+        String errorMessage = "Problem getting file for project (" +
+                projectId + ")";
+
+        for (MediaType mediaType : accepts) {
+            String extension = supportedFormats.get(mediaType.toString());
+            if (null != extension) {
+                try {
+                    return getDocument(
+                            documentService.createAsciiDocument(projectId,
+                                    extension), extension);
+                } catch (IOException e) {
+                    logger.error(errorMessage);
+                    throw new InternalException(errorMessage);
+                }
+            }
         }
+        logger.error(errorMessage);
+        throw new InternalException(errorMessage);
     }
 
     @GetMapping(SLASH + TEMPLATE + SLASH + TEMPLATE_ID_PARAMETER + SLASH +
@@ -95,7 +114,7 @@ public class DocumentController {
             @PathVariable(TEMPLATE_ID) UUID templateId)
             throws IOException {
         Template template = templateService.findById(templateId);
-        if (null != template.getFileNameInternal()) {
+        if (null == template.getFileNameInternal()) {
             throw new InternalException("Can't download document, no filename" +
                     "for template " + templateId);
         }
@@ -103,15 +122,13 @@ public class DocumentController {
         return getDocument(file, template.getTemplateName());
     }
 
-    private HttpEntity<byte[]> getDocument(Path file, String filename)
+    private HttpEntity<byte[]> getDocument(Path file,  String contentType)
             throws IOException {
-
         Resource resource = new UrlResource(file.toUri());
         HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.add("Content-Type",
-                "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        responseHeaders.add("Content-Type", contentType);
         String header = "Content-Disposition";
-        String value = "\"attachment; filename=\"" + filename + "\"";
+        String value = "\"attachment; filename=\"" + file.getFileName() + "\"";
 
         responseHeaders.add(header, value);
 

--- a/src/main/java/no/kdrs/grouse/controller/DocumentController.java
+++ b/src/main/java/no/kdrs/grouse/controller/DocumentController.java
@@ -64,7 +64,7 @@ public class DocumentController {
         Project project = projectService.updateProjectFinalised(projectId);
         // We should revisit this in case there is a need to undo setting the
         // document to finalised if the document cannot be created.
-        documentService.createAsciiDocument(project);
+        documentService.createAsciiDocument(project, "docx");
         return commonController.addProjectLinks(project, CREATED);
     }
 

--- a/src/main/java/no/kdrs/grouse/document/AsciiDoc.java
+++ b/src/main/java/no/kdrs/grouse/document/AsciiDoc.java
@@ -1,170 +1,115 @@
 package no.kdrs.grouse.document;
 
-import no.kdrs.grouse.model.ProjectFunctionality;
 import no.kdrs.grouse.model.ProjectRequirement;
-import org.apache.poi.xwpf.usermodel.*;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.*;
 
-import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import static no.kdrs.grouse.utils.Constants.*;
+import static java.lang.Integer.max;
 
-/**
- * Created by tsodring on 10/28/17.
- */
 public class AsciiDoc {
 
-    private OutputStream out;
-    private XWPFDocument document;
-    private XWPFStyles styles;
-    // A table object that gets reinstantiated every time a new table is
-    // created. Not using an array of tables as we likely do not need access
-    // to the table after it has been added to the document
-    private XWPFTable table;
+    private BufferedWriter asciiDoc;
+    private Map<String, List<String>> properties = new HashMap<>();
 
-    private String headingLevel1 = "headingLevel1";
-    private String headingLevel2 = "headingLevel2";
-
-    // The current row in the table when adding content
-    // is reset every time a table is created
-    private int rowNumber = 1;
-
-
-    public AsciiDoc(OutputStream out) {
-        this.out = out;
-        this.document = new XWPFDocument();
-        XWPFStyles styles = document.createStyles();
-
-        addCustomHeadingStyle(document, styles, headingLevel1, 1, 36, "4288BC");
-        addCustomHeadingStyle(document, styles, headingLevel2, 2, 28, "4288BC");
+    public AsciiDoc(FileWriter fileWriter) {
+        initialiseProperties();
+        asciiDoc = new BufferedWriter(fileWriter);
     }
 
-    public void addRow(ProjectRequirement requirement) {
-        XWPFTableRow row = table.getRow(rowNumber++);
-        row.getCell(COLUMN_NUMBER).setText(Integer.toString(rowNumber));
-        row.getCell(COLUMN_FUNCTIONALITY_TITLE).setText(requirement.getRequirementText());
-        row.getCell(COLUMN_PRIORITY).setText(requirement.getPriority());
-        row.getCell(COLUMN_ANSWER).setText("");
-        row.getCell(COLUMN_REFERENCE).setText("");
-     }
-
-    public void addSection(String sectionTitle) {
-        XWPFParagraph paragraph = document.createParagraph();
-        XWPFRun run = paragraph.createRun();
-        run.setText(sectionTitle);
-        run.addBreak();
+    public void addSectionHeader(String title, int level)
+            throws IOException {
+        String section = "=".repeat(max(0, level)) + " ";
+        asciiDoc.write(section + title);
+        asciiDoc.newLine();
+        asciiDoc.newLine();
     }
 
-    public void addHeading1(String sectionTitle) {
-        XWPFParagraph paragraph = document.createParagraph();
-        paragraph.setStyle(headingLevel1);
-        XWPFRun run = paragraph.createRun();
-        run.setText(sectionTitle);
-        run.addBreak();
+    public void addText(String text) throws IOException {
+        asciiDoc.newLine();
+        asciiDoc.write(text);
+        asciiDoc.newLine();
     }
 
-    public void addHeading2(String sectionTitle) {
-        XWPFParagraph paragraph = document.createParagraph();
-        paragraph.setStyle(headingLevel2);
-        XWPFRun run = paragraph.createRun();
-        run.setText(sectionTitle);
-        run.addBreak();
+    public void createTable(String title) throws IOException {
+        asciiDoc.write("." + title);
+        asciiDoc.newLine();
+        asciiDoc.write("[cols=\"" + getColWidth("1") + "," +
+                getColWidth("2") + "," +
+                getColWidth("3") + "," +
+                getColWidth("4") + "," +
+                getColWidth("5") + "\"" +
+                ", options = \"header\"]");
+        asciiDoc.newLine();
+        asciiDoc.write("|===");
+        asciiDoc.newLine();
+        asciiDoc.write("| " + getColText("1") +
+                "| " + getColText("2") +
+                "| " + getColText("3") +
+                "| " + getColText("4") +
+                "| " + getColText("5"));
+        asciiDoc.newLine();
     }
 
-    public void addText(String text) {
-        XWPFParagraph paragraph = document.createParagraph();
-        XWPFRun run = paragraph.createRun();
-        run.setFontSize(11);
-        run.setText(text);
-        run.addBreak();
+    public void endTable() throws IOException {
+        asciiDoc.write("|===");
+        asciiDoc.newLine();
     }
 
-    public void createTable(Integer numberOfRows, ProjectFunctionality
-            functionality) {
+    public void addRow(ProjectRequirement requirement,
+                       String functionalityNumber,
+                       Integer requirementNumber) throws IOException {
+        if (!functionalityNumber.isEmpty()) {
+            asciiDoc.write("| " + functionalityNumber +
+                    "." + requirementNumber.toString());
+        } else {
+            asciiDoc.write("| " + requirementNumber.toString());
+        }
+        asciiDoc.write(" | " + requirement.getRequirementText().strip());
+        asciiDoc.write(" | " + requirement.getPriority());
+        asciiDoc.write(" | ");
+        asciiDoc.write(" |");
+        asciiDoc.newLine();
+    }
 
-            rowNumber = 1;
-            // Add 1 to include the header
-            table = document.createTable(numberOfRows + 1, REQUIRMENT_TABLE_NUMBER_COLUMNS);
-            table.getCTTbl().addNewTblGrid().addNewGridCol().setW(BigInteger.valueOf(REQUIRMENT_TABLE_NUMBER_WIDTH));
-            table.getCTTbl().getTblGrid().addNewGridCol().setW(BigInteger.valueOf(REQUIRMENT_TABLE_TITLE_WIDTH));
-            table.getCTTbl().getTblGrid().addNewGridCol().setW(BigInteger.valueOf(REQUIRMENT_TABLE_PRIORITY_WIDTH));
-            table.getCTTbl().getTblGrid().addNewGridCol().setW(BigInteger.valueOf(REQUIRMENT_TABLE_ANSWER_WIDTH));
-            table.getCTTbl().getTblGrid().addNewGridCol().setW(BigInteger.valueOf(REQUIRMENT_TABLE_REFERENCE_WIDTH));
+    public void addToc() throws IOException {
+        asciiDoc.newLine();
+        asciiDoc.write(":toc:");
+        asciiDoc.newLine();
+        asciiDoc.newLine();
+    }
 
-            // Get the first row and add header values
-            XWPFTableRow row = table.getRow(0);
-            row.getCell(COLUMN_NUMBER).setText(TEXT_REQUIREMENT_NUMBER);
-            row.getCell(COLUMN_FUNCTIONALITY_TITLE).setText(functionality.getTitle());
-            row.getCell(COLUMN_PRIORITY).setText(TEXT_REQUIREMENT_PRIORITY);
-            row.getCell(COLUMN_ANSWER).setText(TEXT_REQUIREMENT_ANSWER);
-            row.getCell(COLUMN_REFERENCE).setText(TEXT_REFERENCE_REQUIREMENT);
+    public void addPageBreak() throws IOException {
+        asciiDoc.newLine();
+        asciiDoc.write("<<<");
+        asciiDoc.newLine();
+        asciiDoc.newLine();
     }
 
     public void close() throws IOException {
-        document.write(out);
+        asciiDoc.newLine();
+        asciiDoc.flush();
+        asciiDoc.close();
     }
 
-
-    private static void addCustomHeadingStyle(XWPFDocument docxDocument, XWPFStyles styles,
-                                              String strStyleId, int headingLevel, int pointSize, String hexColor) {
-
-        CTStyle ctStyle = CTStyle.Factory.newInstance();
-        ctStyle.setStyleId(strStyleId);
-
-
-        CTString styleName = CTString.Factory.newInstance();
-        styleName.setVal(strStyleId);
-        ctStyle.setName(styleName);
-
-        CTDecimalNumber indentNumber = CTDecimalNumber.Factory.newInstance();
-        indentNumber.setVal(BigInteger.valueOf(headingLevel));
-
-        // lower number > style is more prominent in the formats bar
-        ctStyle.setUiPriority(indentNumber);
-
-        CTOnOff onoffnull = CTOnOff.Factory.newInstance();
-        ctStyle.setUnhideWhenUsed(onoffnull);
-
-        // style shows up in the formats bar
-        ctStyle.setQFormat(onoffnull);
-
-        // style defines a heading of the given level
-        CTPPr ppr = CTPPr.Factory.newInstance();
-        ppr.setOutlineLvl(indentNumber);
-        ctStyle.setPPr(ppr);
-
-        XWPFStyle style = new XWPFStyle(ctStyle);
-
-        CTHpsMeasure size = CTHpsMeasure.Factory.newInstance();
-        size.setVal(new BigInteger(String.valueOf(pointSize)));
-        CTHpsMeasure size2 = CTHpsMeasure.Factory.newInstance();
-        size2.setVal(new BigInteger("24"));
-
-        CTFonts fonts = CTFonts.Factory.newInstance();
-        fonts.setAscii("Loma" );
-
-        CTRPr rpr = CTRPr.Factory.newInstance();
-        rpr.setRFonts(fonts);
-        rpr.setSz(size);
-        rpr.setSzCs(size2);
-
-        CTColor color=CTColor.Factory.newInstance();
-        color.setVal(hexToBytes(hexColor));
-        rpr.setColor(color);
-        style.getCTStyle().setRPr(rpr);
-        // is a null op if already defined
-
-        style.setType(STStyleType.PARAGRAPH);
-        styles.addStyle(style);
-
+    private String getColText(String colNumber) {
+        return properties.get("col" + colNumber).get(0);
     }
 
-    public static byte[] hexToBytes(String hexString) {
-        HexBinaryAdapter adapter = new HexBinaryAdapter();
-        byte[] bytes = adapter.unmarshal(hexString);
-        return bytes;
+    private String getColWidth(String colNumber) {
+        return properties.get("col" + colNumber).get(1);
+    }
+
+    protected void initialiseProperties() {
+        properties.put("col1", Arrays.asList("Nr.", "10%"));
+        properties.put("col2", Arrays.asList("Beskrivelse", "50%"));
+        properties.put("col3", Arrays.asList("Pri.", "10%"));
+        properties.put("col4", Arrays.asList("Svar", "20%"));
+        properties.put("col5", Arrays.asList("Ref.", "10%"));
     }
 }

--- a/src/main/java/no/kdrs/grouse/document/AsciiDoc.java
+++ b/src/main/java/no/kdrs/grouse/document/AsciiDoc.java
@@ -15,7 +15,7 @@ import static no.kdrs.grouse.utils.Constants.*;
 /**
  * Created by tsodring on 10/28/17.
  */
-public class Document {
+public class AsciiDoc {
 
     private OutputStream out;
     private XWPFDocument document;
@@ -33,9 +33,7 @@ public class Document {
     private int rowNumber = 1;
 
 
-
-
-    public Document(OutputStream out) {
+    public AsciiDoc(OutputStream out) {
         this.out = out;
         this.document = new XWPFDocument();
         XWPFStyles styles = document.createStyles();

--- a/src/main/java/no/kdrs/grouse/document/AsciiDoc.java
+++ b/src/main/java/no/kdrs/grouse/document/AsciiDoc.java
@@ -27,7 +27,6 @@ public class AsciiDoc {
         String section = "=".repeat(max(0, level)) + " ";
         asciiDoc.write(section + title);
         asciiDoc.newLine();
-        asciiDoc.newLine();
     }
 
     public void addText(String text) throws IOException {
@@ -77,7 +76,8 @@ public class AsciiDoc {
         asciiDoc.newLine();
     }
 
-    public void addToc() throws IOException {
+    public void addHeader() throws IOException {
+        asciiDoc.write(":sectnums: ");
         asciiDoc.newLine();
         asciiDoc.write(":toc:");
         asciiDoc.newLine();

--- a/src/main/java/no/kdrs/grouse/listeners/GrouseEventListener.java
+++ b/src/main/java/no/kdrs/grouse/listeners/GrouseEventListener.java
@@ -1,4 +1,4 @@
-package no.kdrs.grouse;
+package no.kdrs.grouse.listeners;
 
 import no.kdrs.grouse.listeners.GrouseCreationEvent;
 import no.kdrs.grouse.model.AccessControl;

--- a/src/main/java/no/kdrs/grouse/model/SupportedFormats.java
+++ b/src/main/java/no/kdrs/grouse/model/SupportedFormats.java
@@ -1,0 +1,19 @@
+package no.kdrs.grouse.model;
+
+import java.util.Map;
+
+public class SupportedFormats {
+    Map<String, String> supportedFormats;
+
+    public SupportedFormats(Map<String, String> supportedFormats) {
+        this.supportedFormats = supportedFormats;
+    }
+
+    public Map<String, String> getSupportedFormats() {
+        return supportedFormats;
+    }
+
+    public void setSupportedFormats(Map<String, String> supportedFormats) {
+        this.supportedFormats = supportedFormats;
+    }
+}

--- a/src/main/java/no/kdrs/grouse/model/links/LinksSupportedFormats.java
+++ b/src/main/java/no/kdrs/grouse/model/links/LinksSupportedFormats.java
@@ -1,20 +1,17 @@
 package no.kdrs.grouse.model.links;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.*;
-import no.kdrs.grouse.model.Project;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import no.kdrs.grouse.model.SupportedFormats;
-import org.springframework.hateoas.Link;
 import org.springframework.hateoas.RepresentationModel;
 import org.springframework.hateoas.server.core.Relation;
 
-import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
+@EqualsAndHashCode(callSuper = false)
 @Data
 @Relation(collectionRelation = "supportedFormats",
         itemRelation = "supportedFormat")

--- a/src/main/java/no/kdrs/grouse/model/links/LinksSupportedFormats.java
+++ b/src/main/java/no/kdrs/grouse/model/links/LinksSupportedFormats.java
@@ -1,0 +1,41 @@
+package no.kdrs.grouse.model.links;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+import no.kdrs.grouse.model.Project;
+import no.kdrs.grouse.model.SupportedFormats;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.RepresentationModel;
+import org.springframework.hateoas.server.core.Relation;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@Data
+@Relation(collectionRelation = "supportedFormats",
+        itemRelation = "supportedFormat")
+@JsonInclude(NON_NULL)
+public class LinksSupportedFormats
+        extends RepresentationModel<LinksSupportedFormats> {
+
+    private Map<String, String> supportedFormats;
+
+    public LinksSupportedFormats() {
+    }
+
+    public LinksSupportedFormats(SupportedFormats supportedFormats) {
+        this.supportedFormats = supportedFormats.getSupportedFormats();
+    }
+
+    public Map<String, String> getSupportedFormats() {
+        return supportedFormats;
+    }
+
+    public void setSupportedFormats(SupportedFormats supportedFormats) {
+        this.supportedFormats = supportedFormats.getSupportedFormats();
+    }
+}

--- a/src/main/java/no/kdrs/grouse/service/DocumentService.java
+++ b/src/main/java/no/kdrs/grouse/service/DocumentService.java
@@ -22,6 +22,7 @@ import static no.kdrs.grouse.utils.Constants.GROUSE;
 @Component
 @Transactional
 public class DocumentService
+    extends GrouseService
         implements IDocumentService {
 
     @Value("${storage.location}")
@@ -29,7 +30,7 @@ public class DocumentService
 
     @Override
     public void createDocument(Project project) throws IOException {
-
+        checkAccess(project.getProjectId());
         String filename = storageLocation + File.separator +
                 GROUSE + "-" + project.getProjectId().toString() + ".docx";
         project.setFileNameInternal(filename);

--- a/src/main/java/no/kdrs/grouse/service/DocumentService.java
+++ b/src/main/java/no/kdrs/grouse/service/DocumentService.java
@@ -5,7 +5,6 @@ import no.kdrs.grouse.model.Project;
 import no.kdrs.grouse.model.ProjectFunctionality;
 import no.kdrs.grouse.model.ProjectRequirement;
 import no.kdrs.grouse.service.interfaces.IDocumentService;
-
 import no.kdrs.grouse.service.interfaces.IProjectService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +12,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -57,10 +58,12 @@ public class DocumentService
         processAllRequirements(asciiDoc, project);
         asciiDoc.close();
 
+        String formatTo = getFormatTo(extension);
+
         String convertCommand = "asciidoctor --backend docbook --out-file - ";
         convertCommand += filename + ".adoc";
         convertCommand += " | pandoc --from docbook --to ";
-        convertCommand += extension;
+        convertCommand += formatTo;
         convertCommand += " --output " + filename + "." + extension;
 
         // Approach taken from
@@ -79,7 +82,7 @@ public class DocumentService
                     "to " + extension);
             logger.error(e.toString());
         }
-        return Paths.get(filename+ "." + extension);
+        return Paths.get(filename + "." + extension);
     }
 
     /**
@@ -140,5 +143,19 @@ public class DocumentService
                     projectFunctionality.getFunctionalityNumber(), i + 1);
         }
         asciiDoc.endTable();
+    }
+
+    /**
+     * In some cases pandoc uses a word instead of file extension to determine
+     * the to file type. md -> markdown is an example of this
+     *
+     * @param extension The file extension
+     * @return the convert to command if the extension is not enough
+     */
+    private String getFormatTo(String extension) {
+        if (extension.equalsIgnoreCase("md")) {
+            return "markdown";
+        } else
+            return extension;
     }
 }

--- a/src/main/java/no/kdrs/grouse/service/DocumentService.java
+++ b/src/main/java/no/kdrs/grouse/service/DocumentService.java
@@ -1,14 +1,10 @@
 package no.kdrs.grouse.service;
 
-import no.kdrs.grouse.assemblers.APIAssembler;
 import no.kdrs.grouse.document.AsciiDoc;
 import no.kdrs.grouse.model.Project;
 import no.kdrs.grouse.model.ProjectFunctionality;
 import no.kdrs.grouse.model.ProjectRequirement;
 import no.kdrs.grouse.service.interfaces.IDocumentService;
-import org.asciidoctor.Asciidoctor;
-
-import static org.asciidoctor.Asciidoctor.Factory.create;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/no/kdrs/grouse/service/DocumentService.java
+++ b/src/main/java/no/kdrs/grouse/service/DocumentService.java
@@ -6,6 +6,7 @@ import no.kdrs.grouse.model.ProjectFunctionality;
 import no.kdrs.grouse.model.ProjectRequirement;
 import no.kdrs.grouse.service.interfaces.IDocumentService;
 
+import no.kdrs.grouse.service.interfaces.IProjectService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,7 +14,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.UUID;
 
 import static no.kdrs.grouse.utils.Constants.GROUSE;
 
@@ -26,13 +30,19 @@ public class DocumentService
     private static final Logger logger =
             LoggerFactory.getLogger(DocumentService.class);
 
+    private IProjectService projectService;
     @Value("${storage.location}")
     private String storageLocation;
 
+    public DocumentService(IProjectService projectService) {
+        this.projectService = projectService;
+    }
+
     @Override
-    public void createAsciiDocument(Project project, String extension)
+    public Path createAsciiDocument(UUID projectId, String extension)
             throws IOException {
-        checkAccess(project.getProjectId());
+        checkAccess(projectId);
+        Project project = projectService.findById(projectId);
         String filename = storageLocation + File.separator +
                 GROUSE + "-" + project.getProjectId().toString();
         // TODO: Remove filename internal. As filename is based on project,
@@ -69,6 +79,7 @@ public class DocumentService
                     "to " + extension);
             logger.error(e.toString());
         }
+        return Paths.get(filename+ "." + extension);
     }
 
     /**

--- a/src/main/java/no/kdrs/grouse/service/interfaces/IDocumentService.java
+++ b/src/main/java/no/kdrs/grouse/service/interfaces/IDocumentService.java
@@ -1,12 +1,9 @@
 package no.kdrs.grouse.service.interfaces;
 
-import no.kdrs.grouse.document.AsciiDoc;
 import no.kdrs.grouse.model.Project;
 
 import java.io.IOException;
 
 public interface IDocumentService {
-    void createDocument(Project project) throws IOException;
-
-    void processRequirements(AsciiDoc asciiDoc, Project project);
+    void createAsciiDocument(Project project) throws IOException;
 }

--- a/src/main/java/no/kdrs/grouse/service/interfaces/IDocumentService.java
+++ b/src/main/java/no/kdrs/grouse/service/interfaces/IDocumentService.java
@@ -1,6 +1,6 @@
 package no.kdrs.grouse.service.interfaces;
 
-import no.kdrs.grouse.document.Document;
+import no.kdrs.grouse.document.AsciiDoc;
 import no.kdrs.grouse.model.Project;
 
 import java.io.IOException;
@@ -8,5 +8,5 @@ import java.io.IOException;
 public interface IDocumentService {
     void createDocument(Project project) throws IOException;
 
-    void processRequirements(Document document, Project project);
+    void processRequirements(AsciiDoc asciiDoc, Project project);
 }

--- a/src/main/java/no/kdrs/grouse/service/interfaces/IDocumentService.java
+++ b/src/main/java/no/kdrs/grouse/service/interfaces/IDocumentService.java
@@ -5,5 +5,6 @@ import no.kdrs.grouse.model.Project;
 import java.io.IOException;
 
 public interface IDocumentService {
-    void createAsciiDocument(Project project) throws IOException;
+    void createAsciiDocument(Project project, String extension)
+            throws IOException;
 }

--- a/src/main/java/no/kdrs/grouse/service/interfaces/IDocumentService.java
+++ b/src/main/java/no/kdrs/grouse/service/interfaces/IDocumentService.java
@@ -1,10 +1,10 @@
 package no.kdrs.grouse.service.interfaces;
 
-import no.kdrs.grouse.model.Project;
-
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
 
 public interface IDocumentService {
-    void createAsciiDocument(Project project, String extension)
+    Path createAsciiDocument(UUID projectId, String extension)
             throws IOException;
 }

--- a/src/main/java/no/kdrs/grouse/spring/Config.java
+++ b/src/main/java/no/kdrs/grouse/spring/Config.java
@@ -1,9 +1,0 @@
-package no.kdrs.grouse.spring;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.hateoas.config.EnableHypermediaSupport;
-
-@Configuration
-@EnableHypermediaSupport(type = {EnableHypermediaSupport.HypermediaType.HAL})
-public class Config {
-}

--- a/src/main/java/no/kdrs/grouse/utils/CommonController.java
+++ b/src/main/java/no/kdrs/grouse/utils/CommonController.java
@@ -16,6 +16,8 @@ import org.springframework.stereotype.Component;
 
 import javax.validation.constraints.NotNull;
 
+import java.util.Map;
+
 import static no.kdrs.grouse.utils.Constants.NO_ACCESS_OTHER_USER;
 
 /**
@@ -48,6 +50,7 @@ public class CommonController {
     private ProjectFunctionalityAssembler projectFunctionalityAssembler;
     private ProjectRequirementAssembler projectRequirementAssembler;
     private TemplateFunctionalityAssembler templateFunctionalityAssembler;
+    private SupportedFormatAssembler supportedFormatAssembler;
 
     public CommonController(
             RoleValidator role,
@@ -68,7 +71,8 @@ public class CommonController {
             UserAssembler userAssembler,
             ProjectRequirementAssembler projectRequirementAssembler,
             TemplateRequirementAssembler templateRequirementAssembler,
-            ProjectFunctionalityAssembler projectFunctionalityAssembler) {
+            ProjectFunctionalityAssembler projectFunctionalityAssembler,
+            SupportedFormatAssembler supportedFormatAssembler) {
         this.role = role;
         this.pagedUserResourcesAssembler = pagedUserResourcesAssembler;
         this.pagedTemplateResourcesAssembler = pagedTemplateResourcesAssembler;
@@ -88,6 +92,7 @@ public class CommonController {
         this.templateRequirementAssembler = templateRequirementAssembler;
         this.projectFunctionalityAssembler = projectFunctionalityAssembler;
         this.projectRequirementAssembler = projectRequirementAssembler;
+        this.supportedFormatAssembler = supportedFormatAssembler;
     }
 
     public void checkAccess(String ownedBy) {
@@ -249,4 +254,10 @@ public class CommonController {
                 .body(aclAssembler.toModel(aclEntry));
     }
 
+    public ResponseEntity<LinksSupportedFormats>
+    addSupportedFormatsLinks(SupportedFormats supportedFormats,
+                             HttpStatus status) {
+        return ResponseEntity.status(status)
+                .body(supportedFormatAssembler.toModel(supportedFormats));
+    }
 }

--- a/src/main/java/no/kdrs/grouse/utils/Constants.java
+++ b/src/main/java/no/kdrs/grouse/utils/Constants.java
@@ -17,6 +17,7 @@ public final class Constants {
     public static final String SELF = "self";
     public static final String USER = "user";
     public static final String DOCUMENT = "document";
+    public static final String SUPPORTED_FORMATS = "supported-formats";
     public static final String USER_EMAIL_ADDRESS = "user_email_address";
     public static final String SHARE = "share";
     public static final String ACCESS = "access";

--- a/src/main/java/no/kdrs/grouse/utils/Constants.java
+++ b/src/main/java/no/kdrs/grouse/utils/Constants.java
@@ -166,6 +166,8 @@ public final class Constants {
                     "required to see other users";
     public static final String NO_LOGIN_ENDPOINT_METHOD =
             "Endpoint problem for login method ";
+    public static final String NO_COLUMN_ASCIIDOC =
+            "Missing column data for asciidoc. Column number ";
 
     public static final String RESOURCE_TEMPLATES =
             "classpath:templates" + File.separator + "*.xml";

--- a/src/main/resources/application-demo.yml
+++ b/src/main/resources/application-demo.yml
@@ -49,3 +49,8 @@ security:
 
 storage:
   location: /tmp
+# To add an additional format, make sure pandoc can convert from docbook to that format.
+# Grouse uses the following command to convert to odt
+# asciidoctor --backend docbook --out-file - file.adoc | pandoc --from docbook --to odt --output file.odt
+supported:
+  formats: "{ 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' : 'docx', 'application/vnd.oasis.opendocument.text': 'odt', 'text/html': 'html', 'application/pdf': 'pdf', 'application/rtf': 'rtf', 'text/asciidoc': 'adoc', 'text/markdown': 'md' }"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
         default-page-size: 10 # Better for GUI
         max-page-size: 50 # Arbitrarily set
   datasource:
-    url: jdbc:mysql://localhost:3306/kravspec
+    url: jdbc:mysql://localhost:3306/kravspec?serverTimezone=Europe/Oslo
     username: INSERT-USERNAME-HERE
     password: INSERT-PASSWORD-HERE
     driver-class-name: com.mysql.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,7 @@ spring:
           import_files_sql_extractor: org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor
           import_files: db/import.sql
         show_sql: false
-        hbm2ddl.auto: create
+        hbm2ddl.auto: validate
 security:
   oauth2:
     client:
@@ -39,3 +39,9 @@ security:
 
 storage:
   location: /tmp
+# To add an additional format, make sure pandoc can convert from docbook to that format.
+# Grouse uses the following command to convert to odt
+# asciidoctor --backend docbook --out-file - file.adoc | pandoc --from docbook --to odt --output file.odt
+supported:
+  formats: "{ 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' : 'docx', 'application/vnd.oasis.opendocument.text': 'odt', 'text/html': 'html', 'application/pdf': 'pdf', 'application/rtf': 'rtf', 'text/asciidoc': 'adoc', 'text/markdown': 'md' }"
+

--- a/src/main/resources/templates/noark5.xml
+++ b/src/main/resources/templates/noark5.xml
@@ -29,7 +29,31 @@
             <section>
                 <sectionTitle>Sentrale hensyn</sectionTitle>
                 <sectionOrder>2</sectionOrder>
-                <description> For ORG_NAVN er det svært viktig at den løsningen som velges har en funksjonalitet som støtter opp om kommunens kommende arbeidsprosesser, og at brukergrensesnittet er utformet på en måte som fremmer bruk av systemet i tråd med lovpålagte krav og kommunens egne regler og rutiner. Det er et overordnet mål at all saksbehandling i ORG_NAVN skal kunne foregå fullelektronisk. Ny sak- og arkivløsning skal håndtere all saksbehandling fullelektronisk slik at man ikke blir tvunget til å opprettholde papirarkiv pga. begrensninger i løsningen. Jf. forskrift om offentlege arkiv § 2-9 om elektronisk journalføring gjelder følgende « For elektronisk journalføring skal offentlege organ normalt nytte eit arkivsystem som følgjer krava i Noark-standarden. Nye system skal vere godkjende av Riksarkivaren før dei blir tekne i bruk.» Ny systemløsning må være i henhold til NOARK5-standarden, og skal ha endelig godkjenning av Riksarkivaren. ORG_NAVN vil gjennom anskaffelse av nytt sak- og arkivsystem også tilstrebe at så høy andel som mulig av den arkivverdige dokumentproduksjonen fanges opp og arkiveres i sak- og arkivsystemet. Leverandøren må derfor tilby et produkt hvor løsninger og brukergrensesnittet mot den alminnelige saksbehandler er på et slikt nivå at lojalitet til valgt løsning blir best mulig. Fullverdig og komplett integrasjon mot e-postklient som muliggjør direkte saksbehandling og arkivering er en forutsetning. I tillegg til disse momentene vil det være særdeles viktig for Kunden hvordan system- løsningen tilrettelegger for integrasjon med fagsystemer og andre eksterne systemer. Siden ORG_NAVN er under etablering vil organisjonens IKT-portefølje være under utvikling. Leverandør må derfor ta høyde for forventninger om integrasjonsmuligheter for fagsystemer som pr dato ikke er valgt. Valgt systemløsning skal ved driftssetting ha integrasjon mot sentrale løsninger som e-post, tekstbehandler, internettportal, kartløsning etc. Valgt løsning skal legge til rette for at organisjonens nye fagsystemer så enkelt som mulig kan integreres med denne, og at man oppnår elektronisk kommunikasjon mellom sak- og arkivløsning og fagsystem som sikrer at dokumentasjon fra fagsystemene kan arkiveres og gjenfinnes i NOARK5-kjernen. </description>
+                <description>For ORG_NAVN er det svært viktig at den løsningen som velges har en funksjonalitet som
+                    støtter opp om kommunens kommende arbeidsprosesser, og at brukergrensesnittet er utformet på en måte
+                    som fremmer bruk av systemet i tråd med lovpålagte krav og kommunens egne regler og rutiner. Det er
+                    et overordnet mål at all saksbehandling i ORG_NAVN skal kunne foregå fullelektronisk. Ny sak- og
+                    arkivløsning skal håndtere all saksbehandling fullelektronisk slik at man ikke blir tvunget til å
+                    opprettholde papirarkiv pga. begrensninger i løsningen. Jf. forskrift om offentlege arkiv § 2-9 om
+                    elektronisk journalføring gjelder følgende « For elektronisk journalføring skal offentlege organ
+                    normalt nytte eit arkivsystem som følgjer krava i Noark-standarden. Nye system skal vere godkjende
+                    av Riksarkivaren før dei blir tekne i bruk.» Ny systemløsning må være i henhold til
+                    NOARK5-standarden, og skal ha endelig godkjenning av Riksarkivaren. ORG_NAVN vil gjennom anskaffelse
+                    av nytt sak- og arkivsystem også tilstrebe at så høy andel som mulig av den arkivverdige
+                    dokumentproduksjonen fanges opp og arkiveres i sak- og arkivsystemet. Leverandøren må derfor tilby
+                    et produkt hvor løsninger og brukergrensesnittet mot den alminnelige saksbehandler er på et slikt
+                    nivå at lojalitet til valgt løsning blir best mulig. Fullverdig og komplett integrasjon mot
+                    e-postklient som muliggjør direkte saksbehandling og arkivering er en forutsetning. I tillegg til
+                    disse momentene vil det være særdeles viktig for Kunden hvordan system- løsningen tilrettelegger for
+                    integrasjon med fagsystemer og andre eksterne systemer. Siden ORG_NAVN er under etablering vil
+                    organisjonens IKT-portefølje være under utvikling. Leverandør må derfor ta høyde for forventninger
+                    om integrasjonsmuligheter for fagsystemer som pr dato ikke er valgt. Valgt systemløsning skal ved
+                    driftssetting ha integrasjon mot sentrale løsninger som e-post, tekstbehandler, internettportal,
+                    kartløsning etc. Valgt løsning skal legge til rette for at organisjonens nye fagsystemer så enkelt
+                    som mulig kan integreres med denne, og at man oppnår elektronisk kommunikasjon mellom sak- og
+                    arkivløsning og fagsystem som sikrer at dokumentasjon fra fagsystemene kan arkiveres og gjenfinnes i
+                    NOARK5-kjernen.
+                </description>
                 <showMe>false</showMe>
             </section>
         </chapter>
@@ -46,7 +70,27 @@
             <section>
                 <sectionTitle>Om utfylling av tabellene</sectionTitle>
                 <sectionOrder>2</sectionOrder>
-                <description> Nedenfor er en kort beskrivelse av hensikten med kolonnene i tabellene, og hvordan kravtabellene skal fylles ut. Kolonnen «Pri» (prioritet): Angir Kunden sin prioritering av kravene. O= Obligatorisk, 1 = Svært viktig for oppdragsgiver, 2= Viktig for oppdragsgiver Obligatoriske krav skal tilfredsstilles. Manglende tilfredsstillelse av disse eller forbehold knyttet til disse vil kunne regnes som vesentlige forbehold/vesentlig avvik og kan medføre avvisning av tilbudet. Krav merket med 1 eller 2 er viktige og det forventes at disse tilfredsstilles. Hvis kravet ikke kan tilfredsstilles slik det er beskrevet, bes leverandøren kommentere hvordan dette behovet kan ivaretas i løsningen på andre måter. I tillegg er det i denne kolonnen noen krav som er markert med (i). Dette betyr at leverandøren bes gi utfyllende informasjon/beskrive. Denne informasjonen inngår som del av vurderingen av leverandørens oppfyllelse av kundens krav og formål med anskaffelsen. Kolonnen «Svar»: Her skal tilbyder svare i henhold til oppsettet nedenfor. OBS SETT INN TABELL HER!!! NB! Kategorier J-C og J-D Dersom ikke annet er angitt forplikter leverandøren seg til at tilpasning/utvikling inngår i standard-produktet. Kolonnen «Ref» (referanse): Her skal det refereres til det punkt i løsningsbeskrivelsen hvor svaret utdypes. Løsningsbeskrivelsen vil være sentral når det gjelder å sammenligne tilbud der det er svart «Ja» på at leverandør kan tilfredsstille kravet. Til en del av tabellene er det også tatt inn en formålsbeskrivelse. Disse gir viktige føringer for løsning på/håndtering av tilhørende krav, og leverandørens svar vil bli vurdert opp imot disse. Leverandøren skal til hver av tabellene også vurdere om basisløsningen de tilbyr inneholder annen funksjonalitet som støtter opp under formålet, men som ikke eksplisitt er stilt opp som et krav. Dette kommenteres særskilt. OBS SETT INN TABELL HER!!! </description>
+                <description>Nedenfor er en kort beskrivelse av hensikten med kolonnene i tabellene, og hvordan
+                    kravtabellene skal fylles ut. Kolonnen «Pri» (prioritet): Angir Kunden sin prioritering av kravene.
+                    O= Obligatorisk, 1 = Svært viktig for oppdragsgiver, 2= Viktig for oppdragsgiver Obligatoriske krav
+                    skal tilfredsstilles. Manglende tilfredsstillelse av disse eller forbehold knyttet til disse vil
+                    kunne regnes som vesentlige forbehold/vesentlig avvik og kan medføre avvisning av tilbudet. Krav
+                    merket med 1 eller 2 er viktige og det forventes at disse tilfredsstilles. Hvis kravet ikke kan
+                    tilfredsstilles slik det er beskrevet, bes leverandøren kommentere hvordan dette behovet kan
+                    ivaretas i løsningen på andre måter. I tillegg er det i denne kolonnen noen krav som er markert med
+                    (i). Dette betyr at leverandøren bes gi utfyllende informasjon/beskrive. Denne informasjonen inngår
+                    som del av vurderingen av leverandørens oppfyllelse av kundens krav og formål med anskaffelsen.
+                    Kolonnen «Svar»: Her skal tilbyder svare i henhold til oppsettet nedenfor. OBS SETT INN TABELL
+                    HER!!! NB! Kategorier J-C og J-D Dersom ikke annet er angitt forplikter leverandøren seg til at
+                    tilpasning/utvikling inngår i standard-produktet. Kolonnen «Ref» (referanse): Her skal det refereres
+                    til det punkt i løsningsbeskrivelsen hvor svaret utdypes. Løsningsbeskrivelsen vil være sentral når
+                    det gjelder å sammenligne tilbud der det er svart «Ja» på at leverandør kan tilfredsstille kravet.
+                    Til en del av tabellene er det også tatt inn en formålsbeskrivelse. Disse gir viktige føringer for
+                    løsning på/håndtering av tilhørende krav, og leverandørens svar vil bli vurdert opp imot disse.
+                    Leverandøren skal til hver av tabellene også vurdere om basisløsningen de tilbyr inneholder annen
+                    funksjonalitet som støtter opp under formålet, men som ikke eksplisitt er stilt opp som et krav.
+                    Dette kommenteres særskilt. OBS SETT INN TABELL HER!!!
+                </description>
                 <showMe>false</showMe>
             </section>
         </chapter>

--- a/src/main/resources/templates/noark5.xml
+++ b/src/main/resources/templates/noark5.xml
@@ -75,7 +75,7 @@
             <section>
                 <sectionOrder>2</sectionOrder>
                 <sectionTitle>Krav til oppfyllelse av NOARK5-krav O og B</sectionTitle>
-                <description>Kravene i dette kapittelet sikrer at alle obligatoriske (O) og betingede obligatoriske (B) Noark5-krav oppfylles.<description>
+                <description>Kravene i dette kapittelet sikrer at alle obligatoriske (O) og betingede obligatoriske (B) Noark5-krav oppfylles.</description>
                 <explanation>Noark-standarden består av obligatoriske, betinget obligatoriske og valgfrie krav. Obligatoriske og betinget obligatoriske krav må være oppfylt for at løsningen skal anses å være Noark5-godkjent. Dette er en forutsetning for å kunne ivareta kravene stilt i den generelle lovgivningen som berører offentlig forvaltning.Det anbefales at det settes krav til at leverandøren om at korrekt og fullstendig uttrekk skal kunne produseres uten betydelig kostnad for kommunen. Uttrekket skal kunne godkjennes av kommunens arkivdepot.</explanation>
                 <consequence>Ved manglende kravstilling omkring disse spørsmålene kan det være mulig at den leverte løsningen ikke tilfredsstiller de lovpålagte kravene til denne type arkivløsning.</consequence>
                 <type>submenu</type>

--- a/src/main/resources/templates/noark5.xml
+++ b/src/main/resources/templates/noark5.xml
@@ -12,14 +12,12 @@
             <section>
                 <sectionTitle>Dokumentets struktur</sectionTitle>
                 <sectionOrder>1</sectionOrder>
-                <description>
-                    ORG_NAVN skal ha et elektronisk sak-/arkivsystem som er godkjent etter
-                    NOARK5-standarden. I dette ligger at kommunen forutsetter at alle obligatoriske krav etter
-                    NOARK5-standarden er oppfylt i det/de systemene som tilbys. Obligatoriske krav i henhold
-                    til NOARK5-standarden vil derfor ikke beskrives nærmere i dette dokumentet.
-                    Tilbyder plikter å gjøre spesifikt oppmerksom på eventuelle obligatoriske krav som ikke
-                    er oppfylt etter standarden, samt å beskrive hvilke løsninger som eventuelt erstatter
-                    uoppfylte krav.
+                <description>ORG_NAVN skal ha et elektronisk sak-/arkivsystem som er godkjent etter NOARK5-standarden. I
+                    dette ligger at kommunen forutsetter at alle obligatoriske krav etter NOARK5-standarden er oppfylt i
+                    det/de systemene som tilbys. Obligatoriske krav i henhold til NOARK5-standarden vil derfor ikke
+                    beskrives nærmere i dette dokumentet. Tilbyder plikter å gjøre spesifikt oppmerksom på eventuelle
+                    obligatoriske krav som ikke er oppfylt etter standarden, samt å beskrive hvilke løsninger som
+                    eventuelt erstatter uoppfylte krav.
                 </description>
                 <showMe>false</showMe>
             </section>
@@ -31,9 +29,8 @@
             <section>
                 <sectionTitle>Innledning</sectionTitle>
                 <sectionOrder>1</sectionOrder>
-                <description>
-                    Dette kapittelet gir en overordnet beskrivelse av ønsket løsning. De konkrete kravene til løsningen
-                    finnes i de følgende kapitlene. Enkelte krav vil fremstå mer detaljert enn andre. Krav til
+                <description>Dette kapittelet gir en overordnet beskrivelse av ønsket løsning. De konkrete kravene til
+                    løsningen finnes i de følgende kapitlene. Enkelte krav vil fremstå mer detaljert enn andre. Krav til
                     funksjonalitet for å løse oppgaver beskrives som hovedregel uten føringer for hvordan oppgavene
                     eventuelt kan ha sammenheng eller løses ved felles funksjoner. Løsningen skal oppfylle de krav som
                     er angitt. Hvordan krav til funksjonalitet løses i detalj, spesifiseres nærmere i samråd med
@@ -45,37 +42,30 @@
             <section>
                 <sectionTitle>Sentrale hensyn</sectionTitle>
                 <sectionOrder>2</sectionOrder>
-                <description>
-                    For ORG_NAVN er det svært viktig at den løsningen som velges har en funksjonalitet som
-                    støtter opp om kommunens kommende arbeidsprosesser, og at brukergrensesnittet er utformet
-                    på en måte som fremmer bruk av systemet i tråd med lovpålagte krav og kommunens egne
-                    regler og rutiner.
-                    Det er et overordnet mål at all saksbehandling i ORG_NAVN skal kunne foregå
-                    fullelektronisk.
-                    Ny sak- og arkivløsning skal håndtere all saksbehandling fullelektronisk slik at man ikke blir
-                    tvunget til å opprettholde papirarkiv pga. begrensninger i løsningen.
-                    Jf. forskrift om offentlege arkiv § 2-9 om elektronisk journalføring gjelder følgende « For
-                    elektronisk journalføring skal offentlege organ normalt nytte eit arkivsystem som følgjer
-                    krava i Noark-standarden. Nye system skal vere godkjende av Riksarkivaren før dei blir tekne
-                    i bruk.»
-                    Ny systemløsning må være i henhold til NOARK5-standarden, og skal ha endelig
-                    godkjenning av Riksarkivaren.
-                    ORG_NAVN vil gjennom anskaffelse av nytt sak- og arkivsystem også tilstrebe
-                    at så høy andel som mulig av den arkivverdige dokumentproduksjonen fanges opp og
-                    arkiveres i sak- og arkivsystemet. Leverandøren må derfor tilby et produkt hvor løsninger og
-                    brukergrensesnittet mot den alminnelige saksbehandler er på et slikt nivå at lojalitet til valgt
-                    løsning blir best mulig. Fullverdig og komplett integrasjon mot e-postklient som muliggjør
-                    direkte saksbehandling og arkivering er en forutsetning.
-                    I tillegg til disse momentene vil det være særdeles viktig for Kunden hvordan system-
-                    løsningen tilrettelegger for integrasjon med fagsystemer og andre eksterne systemer. Siden
-                    ORG_NAVN er under etablering vil organisjonens IKT-portefølje være under utvikling.
-                    Leverandør må derfor ta høyde for forventninger om integrasjonsmuligheter for fagsystemer
-                    som pr dato ikke er valgt.
-                    Valgt systemløsning skal ved driftssetting ha integrasjon mot sentrale løsninger som e-post,
-                    tekstbehandler, internettportal, kartløsning etc. Valgt løsning skal legge til rette for at
-                    organisjonens nye fagsystemer så enkelt som mulig kan integreres med denne, og at man
-                    oppnår elektronisk kommunikasjon mellom sak- og arkivløsning og fagsystem som sikrer at
-                    dokumentasjon fra fagsystemene kan arkiveres og gjenfinnes i NOARK5-kjernen.
+                <description>For ORG_NAVN er det svært viktig at den løsningen som velges har en funksjonalitet som
+                    støtter opp om kommunens kommende arbeidsprosesser, og at brukergrensesnittet er utformet på en måte
+                    som fremmer bruk av systemet i tråd med lovpålagte krav og kommunens egne regler og rutiner. Det er
+                    et overordnet mål at all saksbehandling i ORG_NAVN skal kunne foregå fullelektronisk. Ny sak- og
+                    arkivløsning skal håndtere all saksbehandling fullelektronisk slik at man ikke blir tvunget til å
+                    opprettholde papirarkiv pga. begrensninger i løsningen. Jf. forskrift om offentlege arkiv § 2-9 om
+                    elektronisk journalføring gjelder følgende « For elektronisk journalføring skal offentlege organ
+                    normalt nytte eit arkivsystem som følgjer krava i Noark-standarden. Nye system skal vere godkjende
+                    av Riksarkivaren før dei blir tekne i bruk.» Ny systemløsning må være i henhold til
+                    NOARK5-standarden, og skal ha endelig godkjenning av Riksarkivaren. ORG_NAVN vil gjennom anskaffelse
+                    av nytt sak- og arkivsystem også tilstrebe at så høy andel som mulig av den arkivverdige
+                    dokumentproduksjonen fanges opp og arkiveres i sak- og arkivsystemet. Leverandøren må derfor tilby
+                    et produkt hvor løsninger og brukergrensesnittet mot den alminnelige saksbehandler er på et slikt
+                    nivå at lojalitet til valgt løsning blir best mulig. Fullverdig og komplett integrasjon mot
+                    e-postklient som muliggjør direkte saksbehandling og arkivering er en forutsetning. I tillegg til
+                    disse momentene vil det være særdeles viktig for Kunden hvordan system- løsningen tilrettelegger for
+                    integrasjon med fagsystemer og andre eksterne systemer. Siden ORG_NAVN er under etablering vil
+                    organisjonens IKT-portefølje være under utvikling. Leverandør må derfor ta høyde for forventninger
+                    om integrasjonsmuligheter for fagsystemer som pr dato ikke er valgt. Valgt systemløsning skal ved
+                    driftssetting ha integrasjon mot sentrale løsninger som e-post, tekstbehandler, internettportal,
+                    kartløsning etc. Valgt løsning skal legge til rette for at organisjonens nye fagsystemer så enkelt
+                    som mulig kan integreres med denne, og at man oppnår elektronisk kommunikasjon mellom sak- og
+                    arkivløsning og fagsystem som sikrer at dokumentasjon fra fagsystemene kan arkiveres og gjenfinnes i
+                    NOARK5-kjernen.
                 </description>
                 <showMe>false</showMe>
             </section>
@@ -87,47 +77,32 @@
             <section>
                 <sectionTitle>Innledning</sectionTitle>
                 <sectionOrder>1</sectionOrder>
-                <description>
-                </description>
+                <description></description>
                 <showMe>false</showMe>
             </section>
             <section>
                 <sectionTitle>Om utfylling av tabellene</sectionTitle>
                 <sectionOrder>2</sectionOrder>
-                <description>
-                    Nedenfor er en kort beskrivelse av hensikten med kolonnene i tabellene, og hvordan kravtabellene
-                    skal fylles ut.
-                    Kolonnen «Pri» (prioritet): Angir Kunden sin prioritering av kravene.
-                    O= Obligatorisk, 1 = Svært viktig for oppdragsgiver, 2= Viktig for oppdragsgiver
-
-                    Obligatoriske krav skal tilfredsstilles. Manglende tilfredsstillelse av disse eller forbehold
-                    knyttet til disse vil kunne regnes som vesentlige forbehold/vesentlig avvik og kan medføre
-                    avvisning av tilbudet.
-
-                    Krav merket med 1 eller 2 er viktige og det forventes at disse tilfredsstilles. Hvis kravet ikke kan
-                    tilfredsstilles slik det er beskrevet, bes leverandøren kommentere hvordan dette behovet
-                    kan ivaretas i løsningen på andre måter.
-
-                    I tillegg er det i denne kolonnen noen krav som er markert med (i). Dette betyr at leverandøren bes
-                    gi utfyllende informasjon/beskrive. Denne informasjonen inngår som del av vurderingen av
-                    leverandørens oppfyllelse av kundens krav og formål med anskaffelsen. Kolonnen «Svar»: Her skal
-                    tilbyder svare i henhold til oppsettet nedenfor.
-
-                    OBS SETT INN TABELL HER!!!
-
-                    NB! Kategorier J-C og J-D
-                    Dersom ikke annet er angitt forplikter leverandøren seg til at tilpasning/utvikling inngår i
-                    standard-produktet. Kolonnen «Ref» (referanse): Her skal det refereres til det punkt i
-                    løsningsbeskrivelsen hvor svaret utdypes. Løsningsbeskrivelsen vil være sentral når det gjelder å
-                    sammenligne tilbud der det er svart «Ja» på at leverandør kan tilfredsstille kravet.
-
+                <description>Nedenfor er en kort beskrivelse av hensikten med kolonnene i tabellene, og hvordan
+                    kravtabellene skal fylles ut. Kolonnen «Pri» (prioritet): Angir Kunden sin prioritering av kravene.
+                    O= Obligatorisk, 1 = Svært viktig for oppdragsgiver, 2= Viktig for oppdragsgiver Obligatoriske krav
+                    skal tilfredsstilles. Manglende tilfredsstillelse av disse eller forbehold knyttet til disse vil
+                    kunne regnes som vesentlige forbehold/vesentlig avvik og kan medføre avvisning av tilbudet. Krav
+                    merket med 1 eller 2 er viktige og det forventes at disse tilfredsstilles. Hvis kravet ikke kan
+                    tilfredsstilles slik det er beskrevet, bes leverandøren kommentere hvordan dette behovet kan
+                    ivaretas i løsningen på andre måter. I tillegg er det i denne kolonnen noen krav som er markert med
+                    (i). Dette betyr at leverandøren bes gi utfyllende informasjon/beskrive. Denne informasjonen inngår
+                    som del av vurderingen av leverandørens oppfyllelse av kundens krav og formål med anskaffelsen.
+                    Kolonnen «Svar»: Her skal tilbyder svare i henhold til oppsettet nedenfor. OBS SETT INN TABELL
+                    HER!!! NB! Kategorier J-C og J-D Dersom ikke annet er angitt forplikter leverandøren seg til at
+                    tilpasning/utvikling inngår i standard-produktet. Kolonnen «Ref» (referanse): Her skal det refereres
+                    til det punkt i løsningsbeskrivelsen hvor svaret utdypes. Løsningsbeskrivelsen vil være sentral når
+                    det gjelder å sammenligne tilbud der det er svart «Ja» på at leverandør kan tilfredsstille kravet.
                     Til en del av tabellene er det også tatt inn en formålsbeskrivelse. Disse gir viktige føringer for
                     løsning på/håndtering av tilhørende krav, og leverandørens svar vil bli vurdert opp imot disse.
                     Leverandøren skal til hver av tabellene også vurdere om basisløsningen de tilbyr inneholder annen
                     funksjonalitet som støtter opp under formålet, men som ikke eksplisitt er stilt opp som et krav.
-                    Dette kommenteres særskilt.
-
-                    OBS SETT INN TABELL HER!!!
+                    Dette kommenteres særskilt. OBS SETT INN TABELL HER!!!
                 </description>
                 <showMe>false</showMe>
             </section>
@@ -166,8 +141,7 @@
                 <sectionOrder>2</sectionOrder>
                 <sectionTitle>Krav til oppfyllelse av NOARK5-krav O og B</sectionTitle>
                 <description>Kravene i dette kapittelet sikrer at alle obligatoriske (O) og betingede obligatoriske (B)
-                    Noark5-krav oppfylles.
-                </description>
+                Noark5-krav oppfylles.
                 <explanation>Noark-standarden består av obligatoriske, betinget obligatoriske og valgfrie krav.
                     Obligatoriske og betinget obligatoriske krav må være oppfylt for at løsningen skal anses å være
                     Noark5-godkjent. Dette er en forutsetning for å kunne ivareta kravene stilt i den generelle
@@ -246,9 +220,9 @@
                     underlagt ulike lover og forskrifter.
                 </description>
                 <explanation>Elektronisk saksbehandling er underlagt lovbestemte krav for elektronisk signatur. Kravene
-                    skal også sikre integritet, konfidensialitet, autentisitet.
-                    For å sikre at organisasjonen etterlever disse bestemmelsene, må kravene i dette kapittelet
-                    oppfylles, og det anbefales at kravene stilles som obligatoriske.
+                    skal også sikre integritet, konfidensialitet, autentisitet. For å sikre at organisasjonen etterlever
+                    disse bestemmelsene, må kravene i dette kapittelet oppfylles, og det anbefales at kravene stilles
+                    som obligatoriske.
                 </explanation>
                 <consequence>Ved manglende kravoppfyllelse innenfor disse områdene vil det være store svakheter og
                     mangler med den tilbudte løsningen.
@@ -393,9 +367,8 @@
                     <explanation>Her beskrives kravene som få strukturere arkivet i logiske deler og hjelpefunksjoner
                         for å kunne gjennomføre operasjoner på logiske strukturer på en effektiv måte. Det er viktig at
                         denne type funksjoner er rettighetsstyrt slik at kun brukere med tillatelse til å benytte disse
-                        har tilgang.
-                        Ikke alle løsninger trenger underarkiv. Hvis underakriv er noe som passers deres organisatorsik
-                        arkivinndeling, anbefales kravet å ansees som obligatorisk.
+                        har tilgang. Ikke alle løsninger trenger underarkiv. Hvis underakriv er noe som passers deres
+                        organisatorsik arkivinndeling, anbefales kravet å ansees som obligatorisk.
                     </explanation>
                     <consequence>Dersom løsningen ikke støtter disse kravene vil det være potensielt kostnadskrevende å
                         generere uttrekk.
@@ -611,8 +584,7 @@
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
                             <requirementText>NOARK 5.7.2 (V): En Basismappe skal kunne ha registrert ingen, ett eller
-                                flere Nøkkelord og et Nøkkelord skal kunne inngå i ingen, ett eller flere
-                                Basismapper
+                                flere Nøkkelord og et Nøkkelord skal kunne inngå i ingen, ett eller flere Basismapper
                             </requirementText>
                             <priority>1</priority>
                         </requirement>
@@ -1055,7 +1027,7 @@
                         </requirement>
                     </requirements>
                 </section>
-                <!-- Start ... check these  -->
+                <!-- Start ... check these -->
                 <section>
                     <sectionOrder>7</sectionOrder>
                     <sectionTitle>Krav til frysing av metadata for mappe</sectionTitle>
@@ -1158,10 +1130,9 @@
                                 bildet/opptaket» (fritekst), «Stedsnavn for opptaket/sted bilde ble tatt (tekst)»,
                                 «Geolokalisering av stedet hvor bildet/opptaket ble tatt / gjort med koordinater fra
                                 f.eks. kamera og smarttelefon». Dersom slike koordinater ikke finnes bør systemet kunne
-                                hente
-                                koordinater fra en kartløsning via Geointegrasjon.
-                                Gitt at krav i kap 10.2, Krav til integrasjon mot kartsystem, oppfylles skal informasjon
-                                om geolokalisering kunne hentes fra disse systemene.
+                                hente koordinater fra en kartløsning via Geointegrasjon. Gitt at krav i kap 10.2, Krav
+                                til integrasjon mot kartsystem, oppfylles skal informasjon om geolokalisering kunne
+                                hentes fra disse systemene.
                             </requirementText>
                             <priority>1</priority>
                         </requirement>
@@ -1186,8 +1157,7 @@
                         </requirement>
                     </requirements>
                 </section>
-                <!-- End ... check these  -->
-
+                <!-- End ... check these -->
                 <section>
                     <sectionOrder>10</sectionOrder>
                     <sectionTitle>Krav til oppsplitting og sammenslåing av mapper, flytting av registreringer
@@ -1710,9 +1680,9 @@
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>2</showOrder>
                             <requirementText>Det skal i tillegg til automatisk fortløpende konvertering være mulig for
-                                brukeren å konvertere filer til godkjent arkivformat både
-                                manuelt for en og en fil og samlet for et definert sett av filer som av en eller annen
-                                årsak ikke har blitt konvertert
+                                brukeren å konvertere filer til godkjent arkivformat både manuelt for en og en fil og
+                                samlet for et definert sett av filer som av en eller annen årsak ikke har blitt
+                                konvertert
                             </requirementText>
                             <priority>1</priority>
                         </requirement>
@@ -3751,8 +3721,8 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 9.4.2 (V): Det skal være mulig å innordne et
-                                beslutningsorgan i organisasjonsstrukturen.
+                            <requirementText>NOARK 9.4.2 (V): Det skal være mulig å innordne et beslutningsorgan i
+                                organisasjonsstrukturen.
                             </requirementText>
                             <priority>O</priority>
                         </requirement>
@@ -4736,11 +4706,9 @@
                     </requirements>
                 </section>
             </section>
-
             <section>
                 <sectionOrder>11</sectionOrder>
                 <sectionTitle>Krav til administrasjon av løsningen</sectionTitle>
-
                 <type>submenu</type>
                 <showMe>true</showMe>
                 <section>
@@ -5125,7 +5093,6 @@
                 <sectionTitle>Krav til sikkerhet, sporbarhet og kontroll</sectionTitle>
                 <type>submenu</type>
                 <showMe>true</showMe>
-
                 <section>
                     <sectionOrder>1</sectionOrder>
                     <sectionTitle>Overordnede krav til sikkerhet</sectionTitle>
@@ -5251,7 +5218,6 @@
                         </requirement>
                     </requirements>
                 </section>
-
                 <section>
                     <sectionOrder>3</sectionOrder>
                     <sectionTitle>Krav til autorisasjon og autentisering</sectionTitle>
@@ -5723,8 +5689,8 @@
                             gjøre tilgjengelig for brukere av ulike eksterne fagsystemer som bruker samme arkiv, for
                             eksempel: 1) Lagring av ny eller endret informasjon i mapper, registreringer,
                             dokumentbeskrivelser, klassifiseringsskjemaer og arkivstruktur, 2) Informasjon om
-                            konvertering av dokumenters filformat, lagring av nye
-                            varianter eller versjoner av dokumenter
+                            konvertering av dokumenters filformat, lagring av nye varianter eller versjoner av
+                            dokumenter
                         </showOrder>
                         <requirementText>1</requirementText>
                         <priority>1</priority>
@@ -5758,8 +5724,8 @@
                             det bare skal registreres at en endring har funnet sted, eller om også gammel verdi/ny verdi
                             skal registreres 3) Angi om lesing av objekter skal logges 4) Angi om søketilslag skal
                             logges 5) Angi om bruk av funksjoner for utskrift skal logges 6) Angi om bruk av funksjoner
-                            for lagring eller eksport av dokument eller metadata
-                            til filområde eller annet program utenfor Noark 5 kjernen skal logges
+                            for lagring eller eksport av dokument eller metadata til filområde eller annet program
+                            utenfor Noark 5 kjernen skal logges
                         </requirementText>
                         <priority>1</priority>
                     </requirement>
@@ -5772,10 +5738,9 @@
                             arkivet 2) Dato og tidspunkt for innskanning eller ankomst til elektronisk mottaksenhet
                             (altså normalt før saksbehandler har begynt behandlingen) 3) Hvem: Løsning, organisatorisk
                             enhet, evt. bruker eller rolle, som har utført lagringen 4) Dokumentformat (filtype,
-                            ekstensjon, mime vedleggstype eller lignende) 5)
-                            Eventuelt nytt dokumentformat dersom dokumentet er konvertert ved mottak 6) Lesbart = j/n,
-                            resultat av kontroll om program for å lese, fremføre eller redigere dokumentformatet var
-                            tilgjenglig ved opprettelsestidspunktet
+                            ekstensjon, mime vedleggstype eller lignende) 5) Eventuelt nytt dokumentformat dersom
+                            dokumentet er konvertert ved mottak 6) Lesbart = j/n, resultat av kontroll om program for å
+                            lese, fremføre eller redigere dokumentformatet var tilgjenglig ved opprettelsestidspunktet
                         </requirementText>
                         <priority>1</priority>
                     </requirement>
@@ -5856,10 +5821,7 @@
                     </requirementText>
                     <priority>1</priority>
                 </requirement>
-                <requirements>
-
-                </requirements>
-
+                <requirements></requirements>
             </section>
         </chapter>
         <chapter>
@@ -5913,7 +5875,6 @@
                     </requirement>
                 </requirements>
             </section>
-
             <section>
                 <sectionOrder>2</sectionOrder>
                 <sectionTitle>Tekniske krav</sectionTitle>
@@ -6196,7 +6157,6 @@
                     </requirement>
                 </requirements>
             </section>
-
         </chapter>
         <chapter>
             <chapterTitle>Krav til integrasjoner i ønsket løsning</chapterTitle>
@@ -6633,7 +6593,6 @@
                     </requirement>
                 </requirements>
             </section>
-
         </chapter>
         <chapter>
             <chapterTitle>Krav til konvertering</chapterTitle>
@@ -6706,3 +6665,4 @@
         </chapter>
     </chapters>
 </template>
+ 

--- a/src/main/resources/templates/noark5.xml
+++ b/src/main/resources/templates/noark5.xml
@@ -75,7 +75,7 @@
             <section>
                 <sectionOrder>2</sectionOrder>
                 <sectionTitle>Krav til oppfyllelse av NOARK5-krav O og B</sectionTitle>
-                <description>Kravene i dette kapittelet sikrer at alle obligatoriske (O) og betingede obligatoriske (B) Noark5-krav oppfylles.
+                <description>Kravene i dette kapittelet sikrer at alle obligatoriske (O) og betingede obligatoriske (B) Noark5-krav oppfylles.<description>
                 <explanation>Noark-standarden består av obligatoriske, betinget obligatoriske og valgfrie krav. Obligatoriske og betinget obligatoriske krav må være oppfylt for at løsningen skal anses å være Noark5-godkjent. Dette er en forutsetning for å kunne ivareta kravene stilt i den generelle lovgivningen som berører offentlig forvaltning.Det anbefales at det settes krav til at leverandøren om at korrekt og fullstendig uttrekk skal kunne produseres uten betydelig kostnad for kommunen. Uttrekket skal kunne godkjennes av kommunens arkivdepot.</explanation>
                 <consequence>Ved manglende kravstilling omkring disse spørsmålene kan det være mulig at den leverte løsningen ikke tilfredsstiller de lovpålagte kravene til denne type arkivløsning.</consequence>
                 <type>submenu</type>

--- a/src/main/resources/templates/noark5.xml
+++ b/src/main/resources/templates/noark5.xml
@@ -12,13 +12,7 @@
             <section>
                 <sectionTitle>Dokumentets struktur</sectionTitle>
                 <sectionOrder>1</sectionOrder>
-                <description>ORG_NAVN skal ha et elektronisk sak-/arkivsystem som er godkjent etter NOARK5-standarden. I
-                    dette ligger at kommunen forutsetter at alle obligatoriske krav etter NOARK5-standarden er oppfylt i
-                    det/de systemene som tilbys. Obligatoriske krav i henhold til NOARK5-standarden vil derfor ikke
-                    beskrives nærmere i dette dokumentet. Tilbyder plikter å gjøre spesifikt oppmerksom på eventuelle
-                    obligatoriske krav som ikke er oppfylt etter standarden, samt å beskrive hvilke løsninger som
-                    eventuelt erstatter uoppfylte krav.
-                </description>
+                <description>ORG_NAVN skal ha et elektronisk sak-/arkivsystem som er godkjent etter NOARK5-standarden. I dette ligger at kommunen forutsetter at alle obligatoriske krav etter NOARK5-standarden er oppfylt i det/de systemene som tilbys. Obligatoriske krav i henhold til NOARK5-standarden vil derfor ikke beskrives nærmere i dette dokumentet. Tilbyder plikter å gjøre spesifikt oppmerksom på eventuelle obligatoriske krav som ikke er oppfylt etter standarden, samt å beskrive hvilke løsninger som eventuelt erstatter uoppfylte krav.</description>
                 <showMe>false</showMe>
             </section>
         </chapter>
@@ -29,44 +23,13 @@
             <section>
                 <sectionTitle>Innledning</sectionTitle>
                 <sectionOrder>1</sectionOrder>
-                <description>Dette kapittelet gir en overordnet beskrivelse av ønsket løsning. De konkrete kravene til
-                    løsningen finnes i de følgende kapitlene. Enkelte krav vil fremstå mer detaljert enn andre. Krav til
-                    funksjonalitet for å løse oppgaver beskrives som hovedregel uten føringer for hvordan oppgavene
-                    eventuelt kan ha sammenheng eller løses ved felles funksjoner. Løsningen skal oppfylle de krav som
-                    er angitt. Hvordan krav til funksjonalitet løses i detalj, spesifiseres nærmere i samråd med
-                    leverandør. Detaljspesifikasjoner skal inngå som del av løsnings beskrivelsen og danne grunnlag for
-                    akseptanse og godkjenning.
-                </description>
+                <description>Dette kapittelet gir en overordnet beskrivelse av ønsket løsning. De konkrete kravene til løsningen finnes i de følgende kapitlene. Enkelte krav vil fremstå mer detaljert enn andre. Krav til funksjonalitet for å løse oppgaver beskrives som hovedregel uten føringer for hvordan oppgavene eventuelt kan ha sammenheng eller løses ved felles funksjoner. Løsningen skal oppfylle de krav som er angitt. Hvordan krav til funksjonalitet løses i detalj, spesifiseres nærmere i samråd med leverandør. Detaljspesifikasjoner skal inngå som del av løsnings beskrivelsen og danne grunnlag for akseptanse og godkjenning.</description>
                 <showMe>false</showMe>
             </section>
             <section>
                 <sectionTitle>Sentrale hensyn</sectionTitle>
                 <sectionOrder>2</sectionOrder>
-                <description>For ORG_NAVN er det svært viktig at den løsningen som velges har en funksjonalitet som
-                    støtter opp om kommunens kommende arbeidsprosesser, og at brukergrensesnittet er utformet på en måte
-                    som fremmer bruk av systemet i tråd med lovpålagte krav og kommunens egne regler og rutiner. Det er
-                    et overordnet mål at all saksbehandling i ORG_NAVN skal kunne foregå fullelektronisk. Ny sak- og
-                    arkivløsning skal håndtere all saksbehandling fullelektronisk slik at man ikke blir tvunget til å
-                    opprettholde papirarkiv pga. begrensninger i løsningen. Jf. forskrift om offentlege arkiv § 2-9 om
-                    elektronisk journalføring gjelder følgende « For elektronisk journalføring skal offentlege organ
-                    normalt nytte eit arkivsystem som følgjer krava i Noark-standarden. Nye system skal vere godkjende
-                    av Riksarkivaren før dei blir tekne i bruk.» Ny systemløsning må være i henhold til
-                    NOARK5-standarden, og skal ha endelig godkjenning av Riksarkivaren. ORG_NAVN vil gjennom anskaffelse
-                    av nytt sak- og arkivsystem også tilstrebe at så høy andel som mulig av den arkivverdige
-                    dokumentproduksjonen fanges opp og arkiveres i sak- og arkivsystemet. Leverandøren må derfor tilby
-                    et produkt hvor løsninger og brukergrensesnittet mot den alminnelige saksbehandler er på et slikt
-                    nivå at lojalitet til valgt løsning blir best mulig. Fullverdig og komplett integrasjon mot
-                    e-postklient som muliggjør direkte saksbehandling og arkivering er en forutsetning. I tillegg til
-                    disse momentene vil det være særdeles viktig for Kunden hvordan system- løsningen tilrettelegger for
-                    integrasjon med fagsystemer og andre eksterne systemer. Siden ORG_NAVN er under etablering vil
-                    organisjonens IKT-portefølje være under utvikling. Leverandør må derfor ta høyde for forventninger
-                    om integrasjonsmuligheter for fagsystemer som pr dato ikke er valgt. Valgt systemløsning skal ved
-                    driftssetting ha integrasjon mot sentrale løsninger som e-post, tekstbehandler, internettportal,
-                    kartløsning etc. Valgt løsning skal legge til rette for at organisjonens nye fagsystemer så enkelt
-                    som mulig kan integreres med denne, og at man oppnår elektronisk kommunikasjon mellom sak- og
-                    arkivløsning og fagsystem som sikrer at dokumentasjon fra fagsystemene kan arkiveres og gjenfinnes i
-                    NOARK5-kjernen.
-                </description>
+                <description> For ORG_NAVN er det svært viktig at den løsningen som velges har en funksjonalitet som støtter opp om kommunens kommende arbeidsprosesser, og at brukergrensesnittet er utformet på en måte som fremmer bruk av systemet i tråd med lovpålagte krav og kommunens egne regler og rutiner. Det er et overordnet mål at all saksbehandling i ORG_NAVN skal kunne foregå fullelektronisk. Ny sak- og arkivløsning skal håndtere all saksbehandling fullelektronisk slik at man ikke blir tvunget til å opprettholde papirarkiv pga. begrensninger i løsningen. Jf. forskrift om offentlege arkiv § 2-9 om elektronisk journalføring gjelder følgende « For elektronisk journalføring skal offentlege organ normalt nytte eit arkivsystem som følgjer krava i Noark-standarden. Nye system skal vere godkjende av Riksarkivaren før dei blir tekne i bruk.» Ny systemløsning må være i henhold til NOARK5-standarden, og skal ha endelig godkjenning av Riksarkivaren. ORG_NAVN vil gjennom anskaffelse av nytt sak- og arkivsystem også tilstrebe at så høy andel som mulig av den arkivverdige dokumentproduksjonen fanges opp og arkiveres i sak- og arkivsystemet. Leverandøren må derfor tilby et produkt hvor løsninger og brukergrensesnittet mot den alminnelige saksbehandler er på et slikt nivå at lojalitet til valgt løsning blir best mulig. Fullverdig og komplett integrasjon mot e-postklient som muliggjør direkte saksbehandling og arkivering er en forutsetning. I tillegg til disse momentene vil det være særdeles viktig for Kunden hvordan system- løsningen tilrettelegger for integrasjon med fagsystemer og andre eksterne systemer. Siden ORG_NAVN er under etablering vil organisjonens IKT-portefølje være under utvikling. Leverandør må derfor ta høyde for forventninger om integrasjonsmuligheter for fagsystemer som pr dato ikke er valgt. Valgt systemløsning skal ved driftssetting ha integrasjon mot sentrale løsninger som e-post, tekstbehandler, internettportal, kartløsning etc. Valgt løsning skal legge til rette for at organisjonens nye fagsystemer så enkelt som mulig kan integreres med denne, og at man oppnår elektronisk kommunikasjon mellom sak- og arkivløsning og fagsystem som sikrer at dokumentasjon fra fagsystemene kan arkiveres og gjenfinnes i NOARK5-kjernen. </description>
                 <showMe>false</showMe>
             </section>
         </chapter>
@@ -83,27 +46,7 @@
             <section>
                 <sectionTitle>Om utfylling av tabellene</sectionTitle>
                 <sectionOrder>2</sectionOrder>
-                <description>Nedenfor er en kort beskrivelse av hensikten med kolonnene i tabellene, og hvordan
-                    kravtabellene skal fylles ut. Kolonnen «Pri» (prioritet): Angir Kunden sin prioritering av kravene.
-                    O= Obligatorisk, 1 = Svært viktig for oppdragsgiver, 2= Viktig for oppdragsgiver Obligatoriske krav
-                    skal tilfredsstilles. Manglende tilfredsstillelse av disse eller forbehold knyttet til disse vil
-                    kunne regnes som vesentlige forbehold/vesentlig avvik og kan medføre avvisning av tilbudet. Krav
-                    merket med 1 eller 2 er viktige og det forventes at disse tilfredsstilles. Hvis kravet ikke kan
-                    tilfredsstilles slik det er beskrevet, bes leverandøren kommentere hvordan dette behovet kan
-                    ivaretas i løsningen på andre måter. I tillegg er det i denne kolonnen noen krav som er markert med
-                    (i). Dette betyr at leverandøren bes gi utfyllende informasjon/beskrive. Denne informasjonen inngår
-                    som del av vurderingen av leverandørens oppfyllelse av kundens krav og formål med anskaffelsen.
-                    Kolonnen «Svar»: Her skal tilbyder svare i henhold til oppsettet nedenfor. OBS SETT INN TABELL
-                    HER!!! NB! Kategorier J-C og J-D Dersom ikke annet er angitt forplikter leverandøren seg til at
-                    tilpasning/utvikling inngår i standard-produktet. Kolonnen «Ref» (referanse): Her skal det refereres
-                    til det punkt i løsningsbeskrivelsen hvor svaret utdypes. Løsningsbeskrivelsen vil være sentral når
-                    det gjelder å sammenligne tilbud der det er svart «Ja» på at leverandør kan tilfredsstille kravet.
-                    Til en del av tabellene er det også tatt inn en formålsbeskrivelse. Disse gir viktige føringer for
-                    løsning på/håndtering av tilhørende krav, og leverandørens svar vil bli vurdert opp imot disse.
-                    Leverandøren skal til hver av tabellene også vurdere om basisløsningen de tilbyr inneholder annen
-                    funksjonalitet som støtter opp under formålet, men som ikke eksplisitt er stilt opp som et krav.
-                    Dette kommenteres særskilt. OBS SETT INN TABELL HER!!!
-                </description>
+                <description> Nedenfor er en kort beskrivelse av hensikten med kolonnene i tabellene, og hvordan kravtabellene skal fylles ut. Kolonnen «Pri» (prioritet): Angir Kunden sin prioritering av kravene. O= Obligatorisk, 1 = Svært viktig for oppdragsgiver, 2= Viktig for oppdragsgiver Obligatoriske krav skal tilfredsstilles. Manglende tilfredsstillelse av disse eller forbehold knyttet til disse vil kunne regnes som vesentlige forbehold/vesentlig avvik og kan medføre avvisning av tilbudet. Krav merket med 1 eller 2 er viktige og det forventes at disse tilfredsstilles. Hvis kravet ikke kan tilfredsstilles slik det er beskrevet, bes leverandøren kommentere hvordan dette behovet kan ivaretas i løsningen på andre måter. I tillegg er det i denne kolonnen noen krav som er markert med (i). Dette betyr at leverandøren bes gi utfyllende informasjon/beskrive. Denne informasjonen inngår som del av vurderingen av leverandørens oppfyllelse av kundens krav og formål med anskaffelsen. Kolonnen «Svar»: Her skal tilbyder svare i henhold til oppsettet nedenfor. OBS SETT INN TABELL HER!!! NB! Kategorier J-C og J-D Dersom ikke annet er angitt forplikter leverandøren seg til at tilpasning/utvikling inngår i standard-produktet. Kolonnen «Ref» (referanse): Her skal det refereres til det punkt i løsningsbeskrivelsen hvor svaret utdypes. Løsningsbeskrivelsen vil være sentral når det gjelder å sammenligne tilbud der det er svart «Ja» på at leverandør kan tilfredsstille kravet. Til en del av tabellene er det også tatt inn en formålsbeskrivelse. Disse gir viktige føringer for løsning på/håndtering av tilhørende krav, og leverandørens svar vil bli vurdert opp imot disse. Leverandøren skal til hver av tabellene også vurdere om basisløsningen de tilbyr inneholder annen funksjonalitet som støtter opp under formålet, men som ikke eksplisitt er stilt opp som et krav. Dette kommenteres særskilt. OBS SETT INN TABELL HER!!! </description>
                 <showMe>false</showMe>
             </section>
         </chapter>
@@ -116,12 +59,8 @@
                 <sectionOrder>1</sectionOrder>
                 <sectionTitle>Generelle krav</sectionTitle>
                 <description>Generelle krav rundt funskjonalitet og frister.</description>
-                <explanation>Det er viktig å få på plass en god overordnet beskrivelse av systemet og forventet
-                    funksjonalitet og frister.
-                </explanation>
-                <consequence>Hvis dette mangler kan det oppstår uklarheter rundt funksjonalitet som systemet støtter og
-                    frister for levering
-                </consequence>
+                <explanation>Det er viktig å få på plass en god overordnet beskrivelse av systemet og forventet funksjonalitet og frister. </explanation>
+                <consequence>Hvis dette mangler kan det oppstår uklarheter rundt funksjonalitet som systemet støtter og frister for levering </consequence>
                 <type>submenu</type>
                 <showMe>true</showMe>
                 <requirements>
@@ -129,86 +68,59 @@
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
                         <priority>O (i)</priority>
-                        <requirementText>Løsning. Leverandøren skal gi en oversiktlig, overordnet og kortfattet
-                            beskrivelse av funksjonalitet, arkitektur, grensesnitt og virkemåte for den tilbudte
-                            løsningen. Herunder skal også funksjoner som er under utvikling eller under planlegging
-                            beskrives tilsvarende, og det skal angis planlagt ferdig-dato.
-                        </requirementText>
+                        <requirementText>Løsning. Leverandøren skal gi en oversiktlig, overordnet og kortfattet beskrivelse av funksjonalitet, arkitektur, grensesnitt og virkemåte for den tilbudte løsningen. Herunder skal også funksjoner som er under utvikling eller under planlegging beskrives tilsvarende, og det skal angis planlagt ferdig-dato. </requirementText>
                     </requirement>
                 </requirements>
             </section>
             <section>
                 <sectionOrder>2</sectionOrder>
                 <sectionTitle>Krav til oppfyllelse av NOARK5-krav O og B</sectionTitle>
-                <description>Kravene i dette kapittelet sikrer at alle obligatoriske (O) og betingede obligatoriske (B)
-                Noark5-krav oppfylles.
-                <explanation>Noark-standarden består av obligatoriske, betinget obligatoriske og valgfrie krav.
-                    Obligatoriske og betinget obligatoriske krav må være oppfylt for at løsningen skal anses å være
-                    Noark5-godkjent. Dette er en forutsetning for å kunne ivareta kravene stilt i den generelle
-                    lovgivningen som berører offentlig forvaltning.Det anbefales at det settes krav til at leverandøren
-                    om at korrekt og fullstendig uttrekk skal kunne produseres uten betydelig kostnad for kommunen.
-                    Uttrekket skal kunne godkjennes av kommunens arkivdepot.
-                </explanation>
-                <consequence>Ved manglende kravstilling omkring disse spørsmålene kan det være mulig at den leverte
-                    løsningen ikke tilfredsstiller de lovpålagte kravene til denne type arkivløsning.
-                </consequence>
+                <description>Kravene i dette kapittelet sikrer at alle obligatoriske (O) og betingede obligatoriske (B) Noark5-krav oppfylles.
+                <explanation>Noark-standarden består av obligatoriske, betinget obligatoriske og valgfrie krav. Obligatoriske og betinget obligatoriske krav må være oppfylt for at løsningen skal anses å være Noark5-godkjent. Dette er en forutsetning for å kunne ivareta kravene stilt i den generelle lovgivningen som berører offentlig forvaltning.Det anbefales at det settes krav til at leverandøren om at korrekt og fullstendig uttrekk skal kunne produseres uten betydelig kostnad for kommunen. Uttrekket skal kunne godkjennes av kommunens arkivdepot.</explanation>
+                <consequence>Ved manglende kravstilling omkring disse spørsmålene kan det være mulig at den leverte løsningen ikke tilfredsstiller de lovpålagte kravene til denne type arkivløsning.</consequence>
                 <type>submenu</type>
                 <showMe>true</showMe>
                 <requirements>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>0</showOrder>
-                        <requirementText>Å ivareta kravene stilt i den generelle lovgivningen som berører offentlig
-                            forvaltning.
-                        </requirementText>
+                        <requirementText>Å ivareta kravene stilt i den generelle lovgivningen som berører offentlig forvaltning. </requirementText>
                         <priority></priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Tilbudt løsning skal være godkjent jfr. NOARK5-standarden. Kopi av
-                            egenerklæringsskjema for NOARK5-godkjenning skal vedlegges.
-                        </requirementText>
+                        <requirementText>Tilbudt løsning skal være godkjent jfr. NOARK5-standarden. Kopi av egenerklæringsskjema for NOARK5-godkjenning skal vedlegges. </requirementText>
                         <priority>0</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Tilbudt sak- og arkivløsning skal oppfylle alle obligatoriske krav til indre og
-                            ytre kjerne jf. NOARK5-standarden.
-                        </requirementText>
+                        <requirementText>Tilbudt sak- og arkivløsning skal oppfylle alle obligatoriske krav til indre og ytre kjerne jf. NOARK5-standarden. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Tilbudt sak- og arkivløsning skal oppfylle alle obligatoriske krav jf.
-                            NOARK5-standardens kapittel 7 - 13.
-                        </requirementText>
+                        <requirementText>Tilbudt sak- og arkivløsning skal oppfylle alle obligatoriske krav jf. NOARK5-standardens kapittel 7 - 13. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>Tilbudt sak- og arkivløsning skal oppfylle alle krav tilindre og ytre kjerne
-                            merket B (Betinget obligatorisk) med unntak av de som spesifikt gjelder fagsystemer.
-                        </requirementText>
+                        <requirementText>Tilbudt sak- og arkivløsning skal oppfylle alle krav tilindre og ytre kjerne merket B (Betinget obligatorisk) med unntak av de som spesifikt gjelder fagsystemer. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Leverandøren skal ta ansvar for at uttrekk til arkivdepot fra levert løsning er
-                            korrekt og blir godkjent av oppdragsgivers arkivdepot.
-                        </requirementText>
+                        <requirementText>Leverandøren skal ta ansvar for at uttrekk til arkivdepot fra levert løsning er korrekt og blir godkjent av oppdragsgivers arkivdepot. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>6</showOrder>
-                        <requirementText>«Track a case» - Spor saken: Det bør være mulig for innbyggerne å følge med på
-                            status for innmeldt sak. Eksempelvis ved bruk av eget sporingsnummer
-                        </requirementText>
+                        <requirementText>«Track a case» - Spor saken: Det bør være mulig for innbyggerne å følge med på status for innmeldt sak. Eksempelvis ved bruk av eget sporingsnummer </requirementText>
                         <priority>1</priority>
                     </requirement>
                 </requirements>
@@ -216,43 +128,28 @@
             <section>
                 <sectionOrder>3</sectionOrder>
                 <sectionTitle>Krav til ivaretakelse av spesielle bestemmelser</sectionTitle>
-                <description>Kravene her gjenspeiler at elektronisk saksbehandling i offentlig og kommunal sektor er
-                    underlagt ulike lover og forskrifter.
-                </description>
-                <explanation>Elektronisk saksbehandling er underlagt lovbestemte krav for elektronisk signatur. Kravene
-                    skal også sikre integritet, konfidensialitet, autentisitet. For å sikre at organisasjonen etterlever
-                    disse bestemmelsene, må kravene i dette kapittelet oppfylles, og det anbefales at kravene stilles
-                    som obligatoriske.
-                </explanation>
-                <consequence>Ved manglende kravoppfyllelse innenfor disse områdene vil det være store svakheter og
-                    mangler med den tilbudte løsningen.
-                </consequence>
+                <description>Kravene her gjenspeiler at elektronisk saksbehandling i offentlig og kommunal sektor er underlagt ulike lover og forskrifter. </description>
+                <explanation>Elektronisk saksbehandling er underlagt lovbestemte krav for elektronisk signatur. Kravene skal også sikre integritet, konfidensialitet, autentisitet. For å sikre at organisasjonen etterlever disse bestemmelsene, må kravene i dette kapittelet oppfylles, og det anbefales at kravene stilles som obligatoriske. </explanation>
+                <consequence>Ved manglende kravoppfyllelse innenfor disse områdene vil det være store svakheter og mangler med den tilbudte løsningen. </consequence>
                 <type>submenu</type>
                 <showMe>true</showMe>
                 <requirements>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Elektronisk saksbehandling er en forutsetning og kravene i
-                            eForvaltningsforskriften må følges.
-                        </requirementText>
+                        <requirementText>Elektronisk saksbehandling er en forutsetning og kravene i eForvaltningsforskriften må følges. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Løsningen skal tilfredsstille kravene i Kravspesifikasjonen for PKI i offentlig
-                            sektor.
-                            https://www.regjeringen.no/nb/dep/fad/aktuelt/nyheter/2010/ny-kravspesifikasjon-for-pki-i-offentlig.html?id=621773
-                            (v. 2.0)
-                        </requirementText>
+                        <requirementText>Løsningen skal tilfredsstille kravene i Kravspesifikasjonen for PKI i offentlig sektor. https://www.regjeringen.no/nb/dep/fad/aktuelt/nyheter/2010/ny-kravspesifikasjon-for-pki-i-offentlig.html?id=621773 (v. 2.0) </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Løsningen skal tilfredsstille kravene som følger av personvernforordningen.
-                        </requirementText>
+                        <requirementText>Løsningen skal tilfredsstille kravene som følger av personvernforordningen. </requirementText>
                         <priority>O</priority>
                     </requirement>
                 </requirements>
@@ -260,91 +157,57 @@
             <section>
                 <sectionOrder>4</sectionOrder>
                 <sectionTitle>Krav til brukergrensesnitt og brukervennlighet</sectionTitle>
-                <description>Kravene her sørger for at løsningen støtter brukernes oppgaver både visuelt og strukturelt,
-                    fremmer bruk av systemet på en egnet måte, og letter arbeidshverdagen ved å være så intuitiv som
-                    mulig, samt ved å tilby brukeren målrettet hjelp med oppgavene ved behov.
-                </description>
-                <explanation>En løsning med god brukervennlighet og et intuitivt brukergrensesnitt gir økt motivasjon i
-                    organisasjonen til å benytte løsningen i den daglige saksbehandlingen. Krav som stilles her vil
-                    derfor øke muligheten for god dokumentfangst og sikker dokumentforvaltning.
-                </explanation>
-                <consequence>Dersom valgt løsning er vanskelig å bruke, viser erfaringer at betydelige deler av
-                    saksbehandlingen foregår på utsiden av sak/arkiv-løsningen, og at organisasjonen dermed taper
-                    dokumentasjon som kan være av vesentlig verdi både for organisasjonen selv og for innbyggerne.
-                </consequence>
+                <description>Kravene her sørger for at løsningen støtter brukernes oppgaver både visuelt og strukturelt, fremmer bruk av systemet på en egnet måte, og letter arbeidshverdagen ved å være så intuitiv som mulig, samt ved å tilby brukeren målrettet hjelp med oppgavene ved behov. </description>
+                <explanation>En løsning med god brukervennlighet og et intuitivt brukergrensesnitt gir økt motivasjon i organisasjonen til å benytte løsningen i den daglige saksbehandlingen. Krav som stilles her vil derfor øke muligheten for god dokumentfangst og sikker dokumentforvaltning. </explanation>
+                <consequence>Dersom valgt løsning er vanskelig å bruke, viser erfaringer at betydelige deler av saksbehandlingen foregår på utsiden av sak/arkiv-løsningen, og at organisasjonen dermed taper dokumentasjon som kan være av vesentlig verdi både for organisasjonen selv og for innbyggerne. </consequence>
                 <type>submenu</type>
                 <showMe>true</showMe>
                 <requirements>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>0</showOrder>
-                        <requirementText>Å sørge for at systemløsningen som velges både visuelt og strukturelt støtter
-                            brukernes oppgaver, fremmer bruk av systemet på en egnet måte, og letter arbeidshverdagen
-                            ved å være så intuitiv som mulig, samt ved å tilby brukeren målrettet hjelp medoppgavene ved
-                            behov.
-                        </requirementText>
+                        <requirementText>Å sørge for at systemløsningen som velges både visuelt og strukturelt støtter brukernes oppgaver, fremmer bruk av systemet på en egnet måte, og letter arbeidshverdagen ved å være så intuitiv som mulig, samt ved å tilby brukeren målrettet hjelp medoppgavene ved behov. </requirementText>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Løsningen skal ha samme utseende/utforming av brukergrensesnitt for alle
-                            brukergrupper slik at intern brukerstøtte på tvers av fagområder lettes, og brukere lett kan
-                            kjenne seg igjen.
-                        </requirementText>
+                        <requirementText>Løsningen skal ha samme utseende/utforming av brukergrensesnitt for alle brukergrupper slik at intern brukerstøtte på tvers av fagområder lettes, og brukere lett kan kjenne seg igjen. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Løsningen skal fungere på en slik måte at brukeren kun har tilgang til/må
-                            forholde seg til informasjon og funksjoner som er relevante for den rollen brukeren har, og
-                            den oppgaven som skal utføres. Et eksempel på dette kan være at brukeren kun skal forholde
-                            seg til skjermbilder og funksjoner relevante for den sakstypen som behandles.
-                        </requirementText>
+                        <requirementText>Løsningen skal fungere på en slik måte at brukeren kun har tilgang til/må forholde seg til informasjon og funksjoner som er relevante for den rollen brukeren har, og den oppgaven som skal utføres. Et eksempel på dette kan være at brukeren kun skal forholde seg til skjermbilder og funksjoner relevante for den sakstypen som behandles. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Løsningen skal inneholde en hjelpefunksjon som tilbyr målrettet hjelp til
-                            brukeren når denne er i gang med en arbeidsoperasjon. Med målrettet menes at brukeren skal
-                            få tilgang til hjelp knyttet til den oppgaven / det arbeidsområdet som er relevant, og skal
-                            slippe å lete igjennom dokumentasjon for å finne denne informasjonen. Hjelpefunksjonen skal
-                            oppdateres samtidig med oppgraderinger, nye versjoner etc. av programvaren for øvrig.
-                        </requirementText>
+                        <requirementText>Løsningen skal inneholde en hjelpefunksjon som tilbyr målrettet hjelp til brukeren når denne er i gang med en arbeidsoperasjon. Med målrettet menes at brukeren skal få tilgang til hjelp knyttet til den oppgaven / det arbeidsområdet som er relevant, og skal slippe å lete igjennom dokumentasjon for å finne denne informasjonen. Hjelpefunksjonen skal oppdateres samtidig med oppgraderinger, nye versjoner etc. av programvaren for øvrig. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>Navigasjon i løsningen skal utelukkende baseres på løsningens menyelementer
-                            eller andre funksjoner for navigasjon. Det skal ikke være nødvendig for brukeren å benytte
-                            navigasjonsmulighetene i nettleser for å f.eks. gå ett eller flere steg «tilbake» i
-                            løsningen eller for å avbryte en arbeidsprosess/oppgave.
-                        </requirementText>
+                        <requirementText>Navigasjon i løsningen skal utelukkende baseres på løsningens menyelementer eller andre funksjoner for navigasjon. Det skal ikke være nødvendig for brukeren å benytte navigasjonsmulighetene i nettleser for å f.eks. gå ett eller flere steg «tilbake» i løsningen eller for å avbryte en arbeidsprosess/oppgave. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Løsningen skal være konsistent på alle områder, inkludert menyer, prinsipper
-                            for navigasjon, tilbakemeldinger til brukerne, etc.
-                        </requirementText>
+                        <requirementText>Løsningen skal være konsistent på alle områder, inkludert menyer, prinsipper for navigasjon, tilbakemeldinger til brukerne, etc. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>6</showOrder>
-                        <requirementText>Feilmeldinger og andre meldinger skal være på norsk. Dersom brukeren setter i
-                            gang en oppgave som det forventes vil ta tid, må brukeren få beskjed om dette.
-                        </requirementText>
+                        <requirementText>Feilmeldinger og andre meldinger skal være på norsk. Dersom brukeren setter i gang en oppgave som det forventes vil ta tid, må brukeren få beskjed om dette. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>7</showOrder>
-                        <requirementText>Feilmeldinger og andre meldinger bør være allment forståelige.
-                        </requirementText>
+                        <requirementText>Feilmeldinger og andre meldinger bør være allment forståelige. </requirementText>
                         <priority>2</priority>
                     </requirement>
                 </requirements>
@@ -360,19 +223,9 @@
                 <section>
                     <sectionOrder>1</sectionOrder>
                     <sectionTitle>Krav til arkivstruktur, arkiv og arkivdeler</sectionTitle>
-                    <description>Kravene i dette kapittelet gir organisasjonen utvidet muligheter til å strukturere og å
-                        dele opp arkivet på ønsket måte og tillegger løsningen viktig automatisert funksjonalitet når
-                        arkivdeler skal avsluttes.
-                    </description>
-                    <explanation>Her beskrives kravene som få strukturere arkivet i logiske deler og hjelpefunksjoner
-                        for å kunne gjennomføre operasjoner på logiske strukturer på en effektiv måte. Det er viktig at
-                        denne type funksjoner er rettighetsstyrt slik at kun brukere med tillatelse til å benytte disse
-                        har tilgang. Ikke alle løsninger trenger underarkiv. Hvis underakriv er noe som passers deres
-                        organisatorsik arkivinndeling, anbefales kravet å ansees som obligatorisk.
-                    </explanation>
-                    <consequence>Dersom løsningen ikke støtter disse kravene vil det være potensielt kostnadskrevende å
-                        generere uttrekk.
-                    </consequence>
+                    <description>Kravene i dette kapittelet gir organisasjonen utvidet muligheter til å strukturere og å dele opp arkivet på ønsket måte og tillegger løsningen viktig automatisert funksjonalitet når arkivdeler skal avsluttes. </description>
+                    <explanation>Her beskrives kravene som få strukturere arkivet i logiske deler og hjelpefunksjoner for å kunne gjennomføre operasjoner på logiske strukturer på en effektiv måte. Det er viktig at denne type funksjoner er rettighetsstyrt slik at kun brukere med tillatelse til å benytte disse har tilgang. Ikke alle løsninger trenger underarkiv. Hvis underakriv er noe som passers deres organisatorsik arkivinndeling, anbefales kravet å ansees som obligatorisk. </explanation>
+                    <consequence>Dersom løsningen ikke støtter disse kravene vil det være potensielt kostnadskrevende å generere uttrekk. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
@@ -385,17 +238,13 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>Ved avslutting av en arkivdel skal alle sakene i arkivdelen kunne avsluttes
-                                i én operasjon. Funksjonen skal være rettighetsstyrt.
-                            </requirementText>
+                            <requirementText>Ved avslutting av en arkivdel skal alle sakene i arkivdelen kunne avsluttes i én operasjon. Funksjonen skal være rettighetsstyrt. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>Det skal være mulig å avslutte mange arkivsaker samtidig. Funksjonen skal
-                                være rettighetsstyrt.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å avslutte mange arkivsaker samtidig. Funksjonen skal være rettighetsstyrt. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -403,54 +252,34 @@
                 <section>
                     <sectionOrder>2</sectionOrder>
                     <sectionTitle>Krav til klassifikasjonssystem og klasse</sectionTitle>
-                    <description>Kravene i dette avsnittet sikrer at organisasjonen skal kunne beskrive de ulike
-                        klassifikasjonssystemene som benyttes.
-                    </description>
-                    <explanation>En organisasjon vil ofte ha behov for å kunne benytte ulike klassifikasjonssystemer som
-                        for eksempel k-koder, fødselsnummer, gårds- og bruksnummer eller eventuelle egne arkivnøkler.
-                        Alle klassifikasjonssystemer skal kunne beskrives slik at man i ettertid kan finne ut hva ulike
-                        koder betyr.
-                    </explanation>
-                    <consequence>For på en effektiv måte å kunne benytte klassifikasjonssystemer korrekt er det helt
-                        nødvendig å kunne beskrive klasser og klassifikasjonssystemet.
-                    </consequence>
+                    <description>Kravene i dette avsnittet sikrer at organisasjonen skal kunne beskrive de ulike klassifikasjonssystemene som benyttes. </description>
+                    <explanation>En organisasjon vil ofte ha behov for å kunne benytte ulike klassifikasjonssystemer som for eksempel k-koder, fødselsnummer, gårds- og bruksnummer eller eventuelle egne arkivnøkler. Alle klassifikasjonssystemer skal kunne beskrives slik at man i ettertid kan finne ut hva ulike koder betyr. </explanation>
+                    <consequence>For på en effektiv måte å kunne benytte klassifikasjonssystemer korrekt er det helt nødvendig å kunne beskrive klasser og klassifikasjonssystemet. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.3.6 (V): En Klasse kan ha registrert ingen, ett eller flere
-                                Nøkkelord og et Nøkkelord skal kunne inngå i ingen, ett eller flere Klasser.
-                            </requirementText>
+                            <requirementText>NOARK 5.3.6 (V): En Klasse kan ha registrert ingen, ett eller flere Nøkkelord og et Nøkkelord skal kunne inngå i ingen, ett eller flere Klasser. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 5.3.8 (V) Et klassifikasjonssystem skal kunne beskrives med
-                                forskjellige klassifikasjonstyper. Eksempel på verdier: «Funksjonsbasert, hierarkisk»,
-                                «Emnebasert, hierarkisk arkivnøkkel», «Emnebasert, ett nivå», «K-koder»,
-                                «Mangefasettert, ikke hierarki», «Objektbasert», «Fødselsnummer», «Gårds- og
-                                bruksnummer»
-                            </requirementText>
+                            <requirementText>NOARK 5.3.8 (V) Et klassifikasjonssystem skal kunne beskrives med forskjellige klassifikasjonstyper. Eksempel på verdier: «Funksjonsbasert, hierarkisk», «Emnebasert, hierarkisk arkivnøkkel», «Emnebasert, ett nivå», «K-koder», «Mangefasettert, ikke hierarki», «Objektbasert», «Fødselsnummer», «Gårds- og bruksnummer» </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>Det skal være mulig å ha flere klassifikasjonssystem tilgjengelig samtidig.
-                                Ved ny versjon av et klassifikasjonssystem skal det ikke gjøres endringer på avsluttede
-                                arkivsaker.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å ha flere klassifikasjonssystem tilgjengelig samtidig. Ved ny versjon av et klassifikasjonssystem skal det ikke gjøres endringer på avsluttede arkivsaker. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>Det skal være mulig å få en oversikt over aktive arkivsaker som vil få ny
-                                kode ved endring i klassifikasjonssystemet.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å få en oversikt over aktive arkivsaker som vil få ny kode ved endring i klassifikasjonssystemet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -459,54 +288,39 @@
                     <sectionOrder>3</sectionOrder>
                     <sectionTitle>Krav til mappe</sectionTitle>
                     <description>Kravene er ment å sikre fleksibilitet i arkivstrukturen.</description>
-                    <explanation>Kravene i dette avsnittet kan være relevante i for flere typer organisasjoner. For
-                        kommuner som skal anskaffe sak/arkiv-system, vil det være anbefalt å stille kravene selv om man
-                        ikke anser dem som relevante.
-                    </explanation>
-                    <consequence>Dersom systemet ikke åpner for “mappe i mappe”, vil man kunne oppleve at
-                        arkivstrukturen blir noe mindre fleksibel.
-                    </consequence>
+                    <explanation>Kravene i dette avsnittet kan være relevante i for flere typer organisasjoner. For kommuner som skal anskaffe sak/arkiv-system, vil det være anbefalt å stille kravene selv om man ikke anser dem som relevante. </explanation>
+                    <consequence>Dersom systemet ikke åpner for “mappe i mappe”, vil man kunne oppleve at arkivstrukturen blir noe mindre fleksibel. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.4.5 (V): En Basismappe skal kunne inngå i andre Basismapper i et
-                                hierarki. Disse er kalt undermapper, og er i modellen skissert med en egenrelasjon.
-                            </requirementText>
+                            <requirementText>NOARK 5.4.5 (V): En Basismappe skal kunne inngå i andre Basismapper i et hierarki. Disse er kalt undermapper, og er i modellen skissert med en egenrelasjon. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 5.4.11 (V) En Saksmappe skal kunne ha registrert ingen eller en
-                                Journalenhet og en Journalenhet kan inngå i ingen, en eller flere Saksmapper.
-                            </requirementText>
+                            <requirementText>NOARK 5.4.11 (V) En Saksmappe skal kunne ha registrert ingen eller en Journalenhet og en Journalenhet kan inngå i ingen, en eller flere Saksmapper. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 5.4.16 (V) Det skal finnes en tjeneste / funksjon for å ajourholde
-                                Journalenhet på en Saksmappe.
-                            </requirementText>
+                            <requirementText>NOARK 5.4.16 (V) Det skal finnes en tjeneste / funksjon for å ajourholde Journalenhet på en Saksmappe. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 5.4.19 (V) Det skal finnes en tjeneste / funksjon for å legge opp og
-                                ajourholde undermapper for en Basismappe (mappehierarki).
-                            </requirementText>
+                            <requirementText>NOARK 5.4.19 (V) Det skal finnes en tjeneste / funksjon for å legge opp og ajourholde undermapper for en Basismappe (mappehierarki). </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>Det skal være mulig å lage prosjektmapper med undermapper organisert på en
-                                slik måte at det vil være lett for saksbehandler å finne egne saker / dokumenter.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å lage prosjektmapper med undermapper organisert på en slik måte at det vil være lett for saksbehandler å finne egne saker / dokumenter. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -515,21 +329,15 @@
                     <sectionOrder>4</sectionOrder>
                     <sectionTitle>Krav til registrering</sectionTitle>
                     <description>Kravet gir anledning til å endre journalenhet på en registrering.</description>
-                    <explanation>Dersom en registrering har blitt foretatt på feil journalenhet, må man ha mulighet til
-                        å endre til riktig journalenhet.
-                    </explanation>
-                    <consequence>Dersom denne funksjonen ikke finnes, vil det kunne ha konsekvenser for mulighet for
-                        gjenfinning av registreringen.
-                    </consequence>
+                    <explanation>Dersom en registrering har blitt foretatt på feil journalenhet, må man ha mulighet til å endre til riktig journalenhet. </explanation>
+                    <consequence>Dersom denne funksjonen ikke finnes, vil det kunne ha konsekvenser for mulighet for gjenfinning av registreringen. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.5.12 (V): Det skal finnes en tjeneste / funksjon for å ajourholde
-                                Journalenhet på en Registrering (Journalpost).
-                            </requirementText>
+                            <requirementText>NOARK 5.5.12 (V): Det skal finnes en tjeneste / funksjon for å ajourholde Journalenhet på en Registrering (Journalpost). </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -538,21 +346,15 @@
                     <sectionOrder>5</sectionOrder>
                     <sectionTitle>Krav til dokumentbeskrivelse og dokumentobjekt</sectionTitle>
                     <description>Kravet gir anledning til å endre journalenhet på en registrering.</description>
-                    <explanation>Dersom en registrering har blitt foretatt på feil journalenhet, må man ha mulighet til
-                        å endre til riktig journalenhet.
-                    </explanation>
-                    <consequence>Dersom denne funksjonen ikke finnes, vil det kunne ha konsekvenser for mulighet for
-                        gjenfinning av registreringen.
-                    </consequence>
+                    <explanation>Dersom en registrering har blitt foretatt på feil journalenhet, må man ha mulighet til å endre til riktig journalenhet. </explanation>
+                    <consequence>Dersom denne funksjonen ikke finnes, vil det kunne ha konsekvenser for mulighet for gjenfinning av registreringen. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.6.5 (V): En dokumentbeskrivelse for et fysisk dokument (f.eks.
-                                papir) skal kunne ha referanse til oppbevaringssted for dokumentet.ri
-                            </requirementText>
+                            <requirementText>NOARK 5.6.5 (V): En dokumentbeskrivelse for et fysisk dokument (f.eks. papir) skal kunne ha referanse til oppbevaringssted for dokumentet.ri </requirementText>
                             <priority>2</priority>
                         </requirement>
                     </requirements>
@@ -560,50 +362,34 @@
                 <section>
                     <sectionOrder>6</sectionOrder>
                     <sectionTitle>Krav til nøkkelord</sectionTitle>
-                    <description>Oppfyllelse av kravene gir mulighet til å definere egendefinerte nøkkelord knyttet til
-                        ulike deler av systemet; klasse, sak (mappe), og journalføring (registrering).
-                    </description>
-                    <explanation>Ved å benytte nøkkelord kan det gjøres søk og filtrering på de ulike delene i systemet.
-                        Med nøkkelord søk vil en kunne søke på tvers av arkivstrukturen.
-                    </explanation>
-                    <consequence>Manglende mulighet for å definere nøkkelord, vil gi ansatte i organisasjonen mindre
-                        mulighet til å søke opp saker og dokumenter på en enkel måte.
-                    </consequence>
+                    <description>Oppfyllelse av kravene gir mulighet til å definere egendefinerte nøkkelord knyttet til ulike deler av systemet; klasse, sak (mappe), og journalføring (registrering). </description>
+                    <explanation>Ved å benytte nøkkelord kan det gjøres søk og filtrering på de ulike delene i systemet. Med nøkkelord søk vil en kunne søke på tvers av arkivstrukturen. </explanation>
+                    <consequence>Manglende mulighet for å definere nøkkelord, vil gi ansatte i organisasjonen mindre mulighet til å søke opp saker og dokumenter på en enkel måte. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.7.1 (V): En Klasse skal kunne ha registrert ingen, ett eller flere
-                                Nøkkelord og et Nøkkelord skal kunne inngå i ingen, ett eller flere Klasser.
-                            </requirementText>
+                            <requirementText>NOARK 5.7.1 (V): En Klasse skal kunne ha registrert ingen, ett eller flere Nøkkelord og et Nøkkelord skal kunne inngå i ingen, ett eller flere Klasser. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 5.7.2 (V): En Basismappe skal kunne ha registrert ingen, ett eller
-                                flere Nøkkelord og et Nøkkelord skal kunne inngå i ingen, ett eller flere Basismapper
-                            </requirementText>
+                            <requirementText>NOARK 5.7.2 (V): En Basismappe skal kunne ha registrert ingen, ett eller flere Nøkkelord og et Nøkkelord skal kunne inngå i ingen, ett eller flere Basismapper </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 5.7.3 (V): En Basisregistrering skal kunne ha registrert ingen, ett
-                                eller flere Nøkkelord og et Nøkkelord skal kunne inngå i ingen, ett eller flere
-                                Basisregistreringer.
-                            </requirementText>
+                            <requirementText>NOARK 5.7.3 (V): En Basisregistrering skal kunne ha registrert ingen, ett eller flere Nøkkelord og et Nøkkelord skal kunne inngå i ingen, ett eller flere Basisregistreringer. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 5.7.4 (V): Det skal finnes en tjeneste / funksjon for å knytte ett
-                                eller flere nøkkelord til klasser, mapper og registreringer (unntatt forenklet
-                                registrering).
-                            </requirementText>
+                            <requirementText>NOARK 5.7.4 (V): Det skal finnes en tjeneste / funksjon for å knytte ett eller flere nøkkelord til klasser, mapper og registreringer (unntatt forenklet registrering). </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -611,33 +397,22 @@
                 <section>
                     <sectionOrder>7</sectionOrder>
                     <sectionTitle>Krav til kryssreferanse</sectionTitle>
-                    <description>Kravene gir mulighet til å kryssreferere mellom Klasser, saker og journalposter.
-                    </description>
-                    <explanation>Kryssreferanse benyttes ofte i forhold til presedenssaker, men kan eksempelvis også
-                        benyttes til å referere mellom ulike saker knyttet til en og samme objektklassifisering (for
-                        eksempel fødselsnummer, gårds- og bruksnummer e.l.)
-                    </explanation>
-                    <consequence>Manglende oppfyllelse av mulighet til kryssreferanser vil gjøre at tilgangen til
-                        relevant informasjon begrenses, og at beslutningsgrunnlaget i saksbehandlingen kan bli
-                        mangelfullt.
-                    </consequence>
+                    <description>Kravene gir mulighet til å kryssreferere mellom Klasser, saker og journalposter. </description>
+                    <explanation>Kryssreferanse benyttes ofte i forhold til presedenssaker, men kan eksempelvis også benyttes til å referere mellom ulike saker knyttet til en og samme objektklassifisering (for eksempel fødselsnummer, gårds- og bruksnummer e.l.) </explanation>
+                    <consequence>Manglende oppfyllelse av mulighet til kryssreferanser vil gjøre at tilgangen til relevant informasjon begrenses, og at beslutningsgrunnlaget i saksbehandlingen kan bli mangelfullt. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.7.5 (V): Fra en Klasse bør det kunne refereres til en eller flere
-                                andre Klasser.
-                            </requirementText>
+                            <requirementText>NOARK 5.7.5 (V): Fra en Klasse bør det kunne refereres til en eller flere andre Klasser. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 5.7.14 (V): Det bør finnes en tjeneste/funksjon som kan lagre,
-                                gjenfinne, endre og slette en Kryssreferanse mellom Klasser
-                            </requirementText>
+                            <requirementText>NOARK 5.7.14 (V): Det bør finnes en tjeneste/funksjon som kan lagre, gjenfinne, endre og slette en Kryssreferanse mellom Klasser </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -645,25 +420,16 @@
                 <section>
                     <sectionOrder>8</sectionOrder>
                     <sectionTitle>Krav til merknader</sectionTitle>
-                    <description>Kravet gir anledning til at organisasjonen fritt kan definere hvilke typer merknader
-                        som skal kunne opprettes i tillegg til de merknadstypene som ligger inne som standard i
-                        løsningen.
-                    </description>
-                    <explanation>Merknadstyper benyttes for å definere hva slags merknad som legges inn (arkivmerknad,
-                        saksbehandlingsmerknad e.l) Merknadstyper kan også gi anledning til å sette opp automatiske søk
-                        i løsningen.
-                    </explanation>
-                    <consequence>Dersom løsningen ikke gir anledning til å definere merknadstyper på egen hånd, mister
-                        man muligheten til å sette opp søk som organisasjonen selv har behov for.
-                    </consequence>
+                    <description>Kravet gir anledning til at organisasjonen fritt kan definere hvilke typer merknader som skal kunne opprettes i tillegg til de merknadstypene som ligger inne som standard i løsningen. </description>
+                    <explanation>Merknadstyper benyttes for å definere hva slags merknad som legges inn (arkivmerknad, saksbehandlingsmerknad e.l) Merknadstyper kan også gi anledning til å sette opp automatiske søk i løsningen. </explanation>
+                    <consequence>Dersom løsningen ikke gir anledning til å definere merknadstyper på egen hånd, mister man muligheten til å sette opp søk som organisasjonen selv har behov for. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.7.20 (V): Det skal være mulig å fritt definere typer merknader.
-                            </requirementText>
+                            <requirementText>NOARK 5.7.20 (V): Det skal være mulig å fritt definere typer merknader. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -671,42 +437,28 @@
                 <section>
                     <sectionOrder>9</sectionOrder>
                     <sectionTitle>Krav til dokumentfangst</sectionTitle>
-                    <description>Kravene er knyttet til helautomatisk fangst av dokumenter fra digitale søknader og
-                        lignende
-                    </description>
-                    <explanation>Det er viktig for løsningen at det er enkelt å integrere arkivsystemet med andre
-                        digitale løsninger slik at dokumenter kan fanges på en effektiv og sikker måte inn til
-                        arkivsystemet. Dersom organisasjonen rutinemessig behandler søknader/saker knyttet til enkelte
-                        systemer, bør man stille et egendefinert krav knyttet til dette eller disse systemene.
-                    </explanation>
-                    <consequence>Dersom løsningen ikke åpner for helautomatisk dokumentfangst, må alle dokumenter
-                        registreres og arkiveres manuelt i systemet, noe som vil øke bemanningsbehovet i arkivtjenesten.
-                    </consequence>
+                    <description>Kravene er knyttet til helautomatisk fangst av dokumenter fra digitale søknader og lignende </description>
+                    <explanation>Det er viktig for løsningen at det er enkelt å integrere arkivsystemet med andre digitale løsninger slik at dokumenter kan fanges på en effektiv og sikker måte inn til arkivsystemet. Dersom organisasjonen rutinemessig behandler søknader/saker knyttet til enkelte systemer, bør man stille et egendefinert krav knyttet til dette eller disse systemene. </explanation>
+                    <consequence>Dersom løsningen ikke åpner for helautomatisk dokumentfangst, må alle dokumenter registreres og arkiveres manuelt i systemet, noe som vil øke bemanningsbehovet i arkivtjenesten. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.8.3 (V): Datafangsten skal skje på en slik måte at dokumentets
-                                utseende (layout integritet) blir opprettholdt.
-                            </requirementText>
+                            <requirementText>NOARK 5.8.3 (V): Datafangsten skal skje på en slik måte at dokumentets utseende (layout integritet) blir opprettholdt. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 5.8.4 (V): Det skal finnes funksjonalitet for helautomatisk
-                                dokumentfangst.
-                            </requirementText>
+                            <requirementText>NOARK 5.8.4 (V): Det skal finnes funksjonalitet for helautomatisk dokumentfangst. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 5.8.7 (V): Ved helautomatisk dokumentfangst skal det være mulig å
-                                knytte dokumenter til en eller flere mapper eller klasser i arkivstrukturen.
-                            </requirementText>
+                            <requirementText>NOARK 5.8.7 (V): Ved helautomatisk dokumentfangst skal det være mulig å knytte dokumenter til en eller flere mapper eller klasser i arkivstrukturen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -720,114 +472,82 @@
                 <section>
                     <sectionOrder>1</sectionOrder>
                     <sectionTitle>Krav til søkefunksjonalitet</sectionTitle>
-                    <description>Kravene i dette avsnittet er ment å sikre at søk etter dokumentasjon i løsningen skal
-                        kunne foregå enkelt, raskt og sikkert.
-                    </description>
-                    <explanation>En god søkefunksjon vil være essensielt for at organisasjonen skal kunne hente ut
-                        gevinstene knyttet til større datafangst og en høyere datakvalitet.
-                    </explanation>
-                    <consequence>Ved manglende eller for dårlig søkefunksjonalitet, vil gjenfinning av dokumentasjon
-                        vanskeliggjøres samtidig som organisasjonens opplevelse av løsningen svekkes. Dette vil i sin
-                        tur kunne gå ut over de ansattes lojalitet til løsningen.
-                    </consequence>
+                    <description>Kravene i dette avsnittet er ment å sikre at søk etter dokumentasjon i løsningen skal kunne foregå enkelt, raskt og sikkert. </description>
+                    <explanation>En god søkefunksjon vil være essensielt for at organisasjonen skal kunne hente ut gevinstene knyttet til større datafangst og en høyere datakvalitet. </explanation>
+                    <consequence>Ved manglende eller for dårlig søkefunksjonalitet, vil gjenfinning av dokumentasjon vanskeliggjøres samtidig som organisasjonens opplevelse av løsningen svekkes. Dette vil i sin tur kunne gå ut over de ansattes lojalitet til løsningen. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.9.14 (V): Det skal finnes en tjeneste / funksjon for å avbryte søk
-                                som er satt i gang.
-                            </requirementText>
+                            <requirementText>NOARK 5.9.14 (V): Det skal finnes en tjeneste / funksjon for å avbryte søk som er satt i gang. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 5.9.15 (V): Søkefunksjonene bør være innrettet slik at en ved søk på
-                                et ord i bokmålsform også får treff for de tilsvarende nynorskformene og omvendt.
-                            </requirementText>
+                            <requirementText>NOARK 5.9.15 (V): Søkefunksjonene bør være innrettet slik at en ved søk på et ord i bokmålsform også får treff for de tilsvarende nynorskformene og omvendt. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>Det skal være mulig å velge å søke i hele løsningen på tvers av strukturer,
-                                saker etc. Det skal også være mulig å begrense søket etter eget behov.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å velge å søke i hele løsningen på tvers av strukturer, saker etc. Det skal også være mulig å begrense søket etter eget behov. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>Det skal være mulig å søke i flere databaser samtidig, dvs. i
-                                produksjonsbaser og historiske baser. Leverandøren skal beskrive hvordan dette behovet
-                                kan løses.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å søke i flere databaser samtidig, dvs. i produksjonsbaser og historiske baser. Leverandøren skal beskrive hvordan dette behovet kan løses. </requirementText>
                             <priority>1 (i)</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>Grensesnittet for søk skal være intuitivt for bruker, dvs. brukeren skal
-                                ikke behøve å kjenne til feltkoder el., og skal ha samme grensesnitt/layout som resten
-                                av løsningen.
-                            </requirementText>
+                            <requirementText>Grensesnittet for søk skal være intuitivt for bruker, dvs. brukeren skal ikke behøve å kjenne til feltkoder el., og skal ha samme grensesnitt/layout som resten av løsningen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>Alle metadata registrert i løsningen skal være søkbare / skal kunne brukes
-                                som søkekriterier enkeltvis eller i kombinasjon.
-                            </requirementText>
+                            <requirementText>Alle metadata registrert i løsningen skal være søkbare / skal kunne brukes som søkekriterier enkeltvis eller i kombinasjon. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>Det bør være mulig å utføre fritekstsøk i innholdet i dokumenter, og søk i
-                                fritekstfelter. Dette bør være mulig enkeltvis eller i kombinasjon med søk i metadata.
-                            </requirementText>
+                            <requirementText>Det bør være mulig å utføre fritekstsøk i innholdet i dokumenter, og søk i fritekstfelter. Dette bør være mulig enkeltvis eller i kombinasjon med søk i metadata. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>Leverandøren skal beskrive eventuelle begrensninger i søkemuligheter
-                                knyttet til kravene ovenfor (1 til 7).
-                            </requirementText>
+                            <requirementText>Leverandøren skal beskrive eventuelle begrensninger i søkemuligheter knyttet til kravene ovenfor (1 til 7). </requirementText>
                             <priority>O (i)</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>Det skal være mulig for brukeren å lagre egendefinerte søk for senere
-                                bruk.
-                            </requirementText>
+                            <requirementText>Det skal være mulig for brukeren å lagre egendefinerte søk for senere bruk. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>Det skal være mulig for Kunden selv å definere søk som settes opp som
-                                «standard» for alle brukere eller utvalgte grupper av brukere.
-                            </requirementText>
+                            <requirementText>Det skal være mulig for Kunden selv å definere søk som settes opp som «standard» for alle brukere eller utvalgte grupper av brukere. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>Løsningen bør ha en synonymordliste slik at brukerne kan få opp treff
-                                basert på synonymer.
-                            </requirementText>
+                            <requirementText>Løsningen bør ha en synonymordliste slik at brukerne kan få opp treff basert på synonymer. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>Småord skal ikke tas med i indekseringen (såkalte stoppord).
-                            </requirementText>
+                            <requirementText>Småord skal ikke tas med i indekseringen (såkalte stoppord). </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
@@ -839,18 +559,13 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>14</showOrder>
-                            <requirementText>Det bør være mulig å «spare» søkeresultatet slik at man som bruker kan åpne
-                                og arbeide med flere elementer fra resultatet uten at selve søkeresultatet blir borte og
-                                søk må utføres på nytt.
-                            </requirementText>
+                            <requirementText>Det bør være mulig å «spare» søkeresultatet slik at man som bruker kan åpne og arbeide med flere elementer fra resultatet uten at selve søkeresultatet blir borte og søk må utføres på nytt. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>15</showOrder>
-                            <requirementText>Alle søkeresultater skal kunne hentes opp i utskriftsvennlig visning, og
-                                skrives ut.
-                            </requirementText>
+                            <requirementText>Alle søkeresultater skal kunne hentes opp i utskriftsvennlig visning, og skrives ut. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
@@ -870,25 +585,16 @@
                 <section>
                     <sectionOrder>2</sectionOrder>
                     <sectionTitle>Krav til bevaring og kassasjon</sectionTitle>
-                    <description>Kravene i avsnittet gir organisasjonen mulighet til å styre kassasjon av egen
-                        dokumentasjon.
-                    </description>
-                    <explanation>Kassasjon betyr sletting eller fysisk destruksjon av dokument. Dersom organisasjonen
-                        benytter anledningen til å kassere arkivmateriale, er kravene i dette avsnittet viktige. Kravene
-                        bør i så tilfelle settes som obligatoriske.
-                    </explanation>
-                    <consequence>Dersom funksjonaliteten i kravene ikke er tilstede i løsningen, mister organisasjonen
-                        mulighet til selv å styre og kontrollere eget kassasjonsreglement.
-                    </consequence>
+                    <description>Kravene i avsnittet gir organisasjonen mulighet til å styre kassasjon av egen dokumentasjon. </description>
+                    <explanation>Kassasjon betyr sletting eller fysisk destruksjon av dokument. Dersom organisasjonen benytter anledningen til å kassere arkivmateriale, er kravene i dette avsnittet viktige. Kravene bør i så tilfelle settes som obligatoriske. </explanation>
+                    <consequence>Dersom funksjonaliteten i kravene ikke er tilstede i løsningen, mister organisasjonen mulighet til selv å styre og kontrollere eget kassasjonsreglement. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.10.14 (V): Andre regler for beregning av bevaringsdato skal kunne
-                                være mulig.
-                            </requirementText>
+                            <requirementText>NOARK 5.10.14 (V): Andre regler for beregning av bevaringsdato skal kunne være mulig. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
@@ -900,10 +606,7 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>Ved kassasjon skal dokumentene slettes fullstendig og ikke «bare fjerne
-                                koblingen» mellom journalpost og dokument. Det skal fremgå av løsningen at dokumentet er
-                                kassert.
-                            </requirementText>
+                            <requirementText>Ved kassasjon skal dokumentene slettes fullstendig og ikke «bare fjerne koblingen» mellom journalpost og dokument. Det skal fremgå av løsningen at dokumentet er kassert. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -912,21 +615,15 @@
                     <sectionOrder>3</sectionOrder>
                     <sectionTitle>Krav til periodisering</sectionTitle>
                     <description>Kravene sørger for en smidig og automatisert periodisering.</description>
-                    <explanation>Når en arkivdel skal periodiseres må løsningen håndterer eksisterende saksmapper.
-                        Kravene sikrer at dette skjer på en automatisert måte.
-                    </explanation>
-                    <consequence>Dersom funksjonaliteten i kravene mangler vil det påføre organisasjonen betydelig
-                        merarbeid når en arkivdel skal periodiseres.
-                    </consequence>
+                    <explanation>Når en arkivdel skal periodiseres må løsningen håndterer eksisterende saksmapper. Kravene sikrer at dette skjer på en automatisert måte. </explanation>
+                    <consequence>Dersom funksjonaliteten i kravene mangler vil det påføre organisasjonen betydelig merarbeid når en arkivdel skal periodiseres. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.11.10 (V): Det skal være mulig å overføre i en samlet, automatisert
-                                prosess.
-                            </requirementText>
+                            <requirementText>NOARK 5.11.10 (V): Det skal være mulig å overføre i en samlet, automatisert prosess. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -934,10 +631,8 @@
                 <section>
                     <sectionOrder>4</sectionOrder>
                     <sectionTitle>Krav til avlevering</sectionTitle>
-                    <description>Kravene sørger for at systemer er i henhold til gjeldende lovverk om arkivuttrekk.
-                    </description>
-                    <explanation>Alle Noark-løsninger skal kunne lage uttrekk som kan deponeres hos et arkivdepot.
-                    </explanation>
+                    <description>Kravene sørger for at systemer er i henhold til gjeldende lovverk om arkivuttrekk. </description>
+                    <explanation>Alle Noark-løsninger skal kunne lage uttrekk som kan deponeres hos et arkivdepot. </explanation>
                     <consequence>Dette er satt til et obligatorisk krav og kan ikke velges bort</consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
@@ -945,8 +640,7 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.12: Samtlige krav under kapittel 5.12 skal være oppfylt.
-                            </requirementText>
+                            <requirementText>NOARK 5.12: Samtlige krav under kapittel 5.12 skal være oppfylt. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -954,30 +648,16 @@
                 <section>
                     <sectionOrder>5</sectionOrder>
                     <sectionTitle>Krav til administrasjon av kjernen</sectionTitle>
-                    <description>Kravene gir organisasjonen mulighet til å selv bestemme om en dokumentbeskrivelse
-                        automatisk skal få status “Dokumentet er ferdigstilt” når en mappe (saksmappe) avsluttes eller
-                        en journalpost ferdigstilles.
-                    </description>
-                    <explanation>Saksstatus (mappe), journalpoststatus (registrering) og dokumentstatus er statuser som
-                        forteller hvor i saksbehandlingen saken, journalposten eller dokumentet befinner seg. Korrekt
-                        bruk av statuser er viktig for at dokumentflyten og arkiveringsprosessen skal gå så smidig som
-                        mulig. Kravet gjør at arbeidet med disse statusene foregår på en enklere og mer automatisert
-                        måte.
-                    </explanation>
-                    <consequence>Dersom kravet ikke oppfylles øker kontrollbehovet og dermed arbeidsmengden i
-                        arkivtjenesten. Samtidig øker risikoen for at dokumenter blir stående med feil status, noe som
-                        kan få konsekvenser for dokumentflyt og arkivuttrekk.
-                    </consequence>
+                    <description>Kravene gir organisasjonen mulighet til å selv bestemme om en dokumentbeskrivelse automatisk skal få status “Dokumentet er ferdigstilt” når en mappe (saksmappe) avsluttes eller en journalpost ferdigstilles. </description>
+                    <explanation>Saksstatus (mappe), journalpoststatus (registrering) og dokumentstatus er statuser som forteller hvor i saksbehandlingen saken, journalposten eller dokumentet befinner seg. Korrekt bruk av statuser er viktig for at dokumentflyten og arkiveringsprosessen skal gå så smidig som mulig. Kravet gjør at arbeidet med disse statusene foregår på en enklere og mer automatisert måte. </explanation>
+                    <consequence>Dersom kravet ikke oppfylles øker kontrollbehovet og dermed arbeidsmengden i arkivtjenesten. Samtidig øker risikoen for at dokumenter blir stående med feil status, noe som kan få konsekvenser for dokumentflyt og arkivuttrekk. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.13.9 (V) Det bør være mulig å parameterstyre at status ”Dokumentet
-                                er ferdigstilt” skal settes automatisk på Dokumentbeskrivelse ved andre statuser på
-                                Mappe eller Registrering
-                            </requirementText>
+                            <requirementText>NOARK 5.13.9 (V) Det bør være mulig å parameterstyre at status ”Dokumentet er ferdigstilt” skal settes automatisk på Dokumentbeskrivelse ved andre statuser på Mappe eller Registrering </requirementText>
                             <priority>2</priority>
                         </requirement>
                     </requirements>
@@ -985,44 +665,28 @@
                 <section>
                     <sectionOrder>6</sectionOrder>
                     <sectionTitle>Krav til sletting av dokumenter</sectionTitle>
-                    <description>Kravene gir organisasjonen mer fleksibilitet når arkivtjenesten ønsker å rydde opp
-                        mengden av versjoner og varianter av dokumenter tilknyttet en registrering (journalpost).
-                    </description>
-                    <explanation>Dokumentproduksjonen i en organisasjon vil over tid medføre at det blir opprettet mange
-                        dokumentversjoner som ikke er arkivverdige. Det kan derfor være ønskelig å kunne slette slike
-                        dokumenter på en effektiv måte. Det er viktig å huske at denne funksjonen må brukes med stor
-                        grad av forsiktighet, slik at det ikke slettes dokumentversjoner som har dokumentasjonsverdi for
-                        organisasjonen.
-                    </explanation>
-                    <consequence>Dersom kravene ikke oppfylles, vil eventuell sletting måtte gjøres manuelt dokument for
-                        dokument.
-                    </consequence>
+                    <description>Kravene gir organisasjonen mer fleksibilitet når arkivtjenesten ønsker å rydde opp mengden av versjoner og varianter av dokumenter tilknyttet en registrering (journalpost). </description>
+                    <explanation>Dokumentproduksjonen i en organisasjon vil over tid medføre at det blir opprettet mange dokumentversjoner som ikke er arkivverdige. Det kan derfor være ønskelig å kunne slette slike dokumenter på en effektiv måte. Det er viktig å huske at denne funksjonen må brukes med stor grad av forsiktighet, slik at det ikke slettes dokumentversjoner som har dokumentasjonsverdi for organisasjonen. </explanation>
+                    <consequence>Dersom kravene ikke oppfylles, vil eventuell sletting måtte gjøres manuelt dokument for dokument. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 5.13.19 (V): Det skal være mulig å utføre sletting av mange inaktive
-                                dokumentversjoner samtidig, f.eks. alle inaktive dokumentversjoner som er funnet etter
-                                et søk.
-                            </requirementText>
+                            <requirementText>NOARK 5.13.19 (V): Det skal være mulig å utføre sletting av mange inaktive dokumentversjoner samtidig, f.eks. alle inaktive dokumentversjoner som er funnet etter et søk. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 5.13.23 (V): Det skal være mulig å slette mange dokumentvarianter
-                                samtidig, f.eks. alle dokumentvarianter som er funnet etter et søk.
-                            </requirementText>
+                            <requirementText>NOARK 5.13.23 (V): Det skal være mulig å slette mange dokumentvarianter samtidig, f.eks. alle dokumentvarianter som er funnet etter et søk. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 5.13.27 (V): Det skal være mulig å slette mange produksjonsformater
-                                samtidig, f.eks. alle produksjonsformater som er funnet etter et søk.
-                            </requirementText>
+                            <requirementText>NOARK 5.13.27 (V): Det skal være mulig å slette mange produksjonsformater samtidig, f.eks. alle produksjonsformater som er funnet etter et søk. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -1031,43 +695,28 @@
                 <section>
                     <sectionOrder>7</sectionOrder>
                     <sectionTitle>Krav til frysing av metadata for mappe</sectionTitle>
-                    <description>Kravene gjør at metadata på relevante arkivenheter og dokumenter har riktige
-                        statusverdier og ikke kan endres uten autorisasjon.
-                    </description>
-                    <explanation>For å sikre kvaliteten og autentisiteten til arkivmaterialet er det viktig å bevise at
-                        dokumenter og metadata ikke er endret.
-                    </explanation>
-                    <consequence>Dersom ikke kravene oppfylles kan det stilles spørsmål hvorvidt arkivmateriale er
-                        autentisk.
-                    </consequence>
+                    <description>Kravene gjør at metadata på relevante arkivenheter og dokumenter har riktige statusverdier og ikke kan endres uten autorisasjon. </description>
+                    <explanation>For å sikre kvaliteten og autentisiteten til arkivmaterialet er det viktig å bevise at dokumenter og metadata ikke er endret. </explanation>
+                    <consequence>Dersom ikke kravene oppfylles kan det stilles spørsmål hvorvidt arkivmateriale er autentisk. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.1.5 (V) Følgende statusverdier skal være tilgjengelige for
-                                Saksmappe: «Opprettet av saksbehandler», «Avsluttet av saksbehandler», «Unntatt
-                                prosesstyring»
-                            </requirementText>
+                            <requirementText>NOARK 6.1.5 (V) Følgende statusverdier skal være tilgjengelige for Saksmappe: «Opprettet av saksbehandler», «Avsluttet av saksbehandler», «Unntatt prosesstyring» </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 6.1.14 (V) Når statusen til en Saksmappe settes til avsluttet, bør
-                                det på Saksmappe fortsatt være mulig å endre de øvrige metadataene. Endringer skal
-                                logges.
-                            </requirementText>
+                            <requirementText>NOARK 6.1.14 (V) Når statusen til en Saksmappe settes til avsluttet, bør det på Saksmappe fortsatt være mulig å endre de øvrige metadataene. Endringer skal logges. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 6.1.15 (V) En avsluttet Saksmappe skal kunne åpnes igjen av
-                                autoriserte roller og personer. Det skal være mulig å parameterstyre hvem som er
-                                autorisert for å åpne en mappe. Åpning av mappe skal logges.
-                            </requirementText>
+                            <requirementText>NOARK 6.1.15 (V) En avsluttet Saksmappe skal kunne åpnes igjen av autoriserte roller og personer. Det skal være mulig å parameterstyre hvem som er autorisert for å åpne en mappe. Åpning av mappe skal logges. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -1084,56 +733,31 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.1.25 (V) Følgende statusverdier for Journalpost skal være
-                                tilgjengelig: «Midlertidig registrering av innkommet dokument», «Saksbehandler har
-                                registrert innkommet dokument», «Reservert dokument, dvs. egenprodusert dokument er
-                                under arbeid», «Ferdigstilt fra saksbehandler», «Godkjent av leder»
-                            </requirementText>
+                            <requirementText>NOARK 6.1.25 (V) Følgende statusverdier for Journalpost skal være tilgjengelig: «Midlertidig registrering av innkommet dokument», «Saksbehandler har registrert innkommet dokument», «Reservert dokument, dvs. egenprodusert dokument er under arbeid», «Ferdigstilt fra saksbehandler», «Godkjent av leder» </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 6.1.28 (V) Det skal ikke være mulig å slette en Registrering med
-                                status ”Ferdigstilt fra saksbehandler» eller ”Godkjent av leder».
-                            </requirementText>
+                            <requirementText>NOARK 6.1.28 (V) Det skal ikke være mulig å slette en Registrering med status ”Ferdigstilt fra saksbehandler» eller ”Godkjent av leder». </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 6.1.35 (V) For Registreringer av inngående dokumenter med status
-                                «midlertidig registrert» eller «registrert av saksbehandler» skal alle metadata på
-                                registrering kunne endres.
-                            </requirementText>
+                            <requirementText>NOARK 6.1.35 (V) For Registreringer av inngående dokumenter med status «midlertidig registrert» eller «registrert av saksbehandler» skal alle metadata på registrering kunne endres. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 6.1.36 (V) For Registrering av egenproduserte dokumenter
-                                (journalposttype «utgående dokument», «Organinternt dokument for oppfølging»,
-                                «Organinternt dokument uten oppfølging» etc.) med status «Registrert av saksbehandler»
-                                og «Ferdigstilt fra saksbehandler» bør det for autorisert personale være mulig å endre
-                                alle metadata. Det bør være mulig å parametersette roller, enheter, grupper og personer
-                                som skal være autorisert. Endringer skal logges.
-                            </requirementText>
+                            <requirementText>NOARK 6.1.36 (V) For Registrering av egenproduserte dokumenter (journalposttype «utgående dokument», «Organinternt dokument for oppfølging», «Organinternt dokument uten oppfølging» etc.) med status «Registrert av saksbehandler» og «Ferdigstilt fra saksbehandler» bør det for autorisert personale være mulig å endre alle metadata. Det bør være mulig å parametersette roller, enheter, grupper og personer som skal være autorisert. Endringer skal logges. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>Løsningen skal støtte, og ha grensesnitt for spesifisering av ekstra
-                                metadata for enkelte dokumenttyper (spesielt foto/video/audio-filer). Det skal være
-                                mulig å registrere «følgende metadata for denne typen dokumenter: «Dato når
-                                bildet/opptaket er tatt (dato), «Opphavsrett (tekst), «Kontekst/formål for
-                                bildet/opptaket» (fritekst), «Stedsnavn for opptaket/sted bilde ble tatt (tekst)»,
-                                «Geolokalisering av stedet hvor bildet/opptaket ble tatt / gjort med koordinater fra
-                                f.eks. kamera og smarttelefon». Dersom slike koordinater ikke finnes bør systemet kunne
-                                hente koordinater fra en kartløsning via Geointegrasjon. Gitt at krav i kap 10.2, Krav
-                                til integrasjon mot kartsystem, oppfylles skal informasjon om geolokalisering kunne
-                                hentes fra disse systemene.
-                            </requirementText>
+                            <requirementText>Løsningen skal støtte, og ha grensesnitt for spesifisering av ekstra metadata for enkelte dokumenttyper (spesielt foto/video/audio-filer). Det skal være mulig å registrere «følgende metadata for denne typen dokumenter: «Dato når bildet/opptaket er tatt (dato), «Opphavsrett (tekst), «Kontekst/formål for bildet/opptaket» (fritekst), «Stedsnavn for opptaket/sted bilde ble tatt (tekst)», «Geolokalisering av stedet hvor bildet/opptaket ble tatt / gjort med koordinater fra f.eks. kamera og smarttelefon». Dersom slike koordinater ikke finnes bør systemet kunne hente koordinater fra en kartløsning via Geointegrasjon. Gitt at krav i kap 10.2, Krav til integrasjon mot kartsystem, oppfylles skal informasjon om geolokalisering kunne hentes fra disse systemene. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -1150,9 +774,7 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.1.40 (V) Metadata for Dokumentbeskrivelse for hoveddokument bør
-                                kunne fylles ut automatisk på basis av metadata fra Registrering ved oppretting.
-                            </requirementText>
+                            <requirementText>NOARK 6.1.40 (V) Metadata for Dokumentbeskrivelse for hoveddokument bør kunne fylles ut automatisk på basis av metadata fra Registrering ved oppretting. </requirementText>
                             <priority>2</priority>
                         </requirement>
                     </requirements>
@@ -1160,64 +782,41 @@
                 <!-- End ... check these -->
                 <section>
                     <sectionOrder>10</sectionOrder>
-                    <sectionTitle>Krav til oppsplitting og sammenslåing av mapper, flytting av registreringer
-                    </sectionTitle>
-                    <description>Kravene sikrer bedre effektivitet og arbeidsflyt når behov for rydding i arkivbasen
-                        oppstår
-                    </description>
-                    <explanation>Det kan være nødvendig å rydde i saksmapper og journalposter feks når en journalpost er
-                        feilregistrert. Noark sikrer muligheten til å flytte journalposter fra en saksmappe til en
-                        annen, men oppfyllelse av disse kravene vil bedre tjenesten.
-                    </explanation>
-                    <consequence>Dersom kravene ikke oppfylles kan dette ha en konsekvens på effektivitet og
-                        arbeidsflyt.
-                    </consequence>
+                    <sectionTitle>Krav til oppsplitting og sammenslåing av mapper, flytting av registreringer </sectionTitle>
+                    <description>Kravene sikrer bedre effektivitet og arbeidsflyt når behov for rydding i arkivbasen oppstår </description>
+                    <explanation>Det kan være nødvendig å rydde i saksmapper og journalposter feks når en journalpost er feilregistrert. Noark sikrer muligheten til å flytte journalposter fra en saksmappe til en annen, men oppfyllelse av disse kravene vil bedre tjenesten. </explanation>
+                    <consequence>Dersom kravene ikke oppfylles kan dette ha en konsekvens på effektivitet og arbeidsflyt. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.2.6 (V) Hvis registreringsID på Basisregistrering i et sakarkiv
-                                benytter det anbefalte formatet åå/nnnnnn-nnnn (dvs. kombinasjonen av saksnummer
-                                (mappeID) og dokumentnummer i saken), bør registreringsID endres automatisk.
-                                Registreringen bør automatisk tildeles første ledige dokumentnummer i Mappen den flyttes
-                                til.
-                            </requirementText>
+                            <requirementText>NOARK 6.2.6 (V) Hvis registreringsID på Basisregistrering i et sakarkiv benytter det anbefalte formatet åå/nnnnnn-nnnn (dvs. kombinasjonen av saksnummer (mappeID) og dokumentnummer i saken), bør registreringsID endres automatisk. Registreringen bør automatisk tildeles første ledige dokumentnummer i Mappen den flyttes til. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 6.2.7 (V) Registreringer som ikke flyttes i Mappe det flyttes
-                                Registreringer fra, skal ikke få endret registreringsID.
-                            </requirementText>
+                            <requirementText>NOARK 6.2.7 (V) Registreringer som ikke flyttes i Mappe det flyttes Registreringer fra, skal ikke få endret registreringsID. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 6.2.8 (V) Det bør være mulig å flytte flere Registreringer som er
-                                tilknyttet samme Mappe i en samlet operasjon.
-                            </requirementText>
+                            <requirementText>NOARK 6.2.8 (V) Det bør være mulig å flytte flere Registreringer som er tilknyttet samme Mappe i en samlet operasjon. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 6.2.11 (V) Det skal være mulig å parameterstyre at andre, spesielt
-                                autoriserte brukere også skal kunne ha tillatelse til å utføre flytting av
-                                Registreringer.
-                            </requirementText>
+                            <requirementText>NOARK 6.2.11 (V) Det skal være mulig å parameterstyre at andre, spesielt autoriserte brukere også skal kunne ha tillatelse til å utføre flytting av Registreringer. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 6.2.12 (V) Det bør være mulig å parameterstyre at alle brukere kan
-                                flytte Registreringer de selv er saksbehandler for, hvis status er «midlertidig
-                                registrert» eller «registrert av saksbehandler».
-                            </requirementText>
+                            <requirementText>NOARK 6.2.12 (V) Det bør være mulig å parameterstyre at alle brukere kan flytte Registreringer de selv er saksbehandler for, hvis status er «midlertidig registrert» eller «registrert av saksbehandler». </requirementText>
                             <priority>2</priority>
                         </requirement>
                     </requirements>
@@ -1226,30 +825,21 @@
                     <sectionOrder>11</sectionOrder>
                     <sectionTitle>Krav til presedens</sectionTitle>
                     <description>Kravene sikrer at tilbudte løsninger har funksjonalitet for presedens</description>
-                    <explanation>Dersom en saksmappe eller journalpost utgjør en presedens feks det fattes et vedtak som
-                        oppfattes som prinsipielt viktig for fremtidig saksbehandling. Senere kan organisasjonen gå
-                        tilbake og gjenbruke dette som presedens.
-                    </explanation>
-                    <consequence>Dersom kravene ikke oppfylles kan det blir vanskeligere å gjenbruke eksisterende saker
-                        og journalposter som presedenser.
-                    </consequence>
+                    <explanation>Dersom en saksmappe eller journalpost utgjør en presedens feks det fattes et vedtak som oppfattes som prinsipielt viktig for fremtidig saksbehandling. Senere kan organisasjonen gå tilbake og gjenbruke dette som presedens. </explanation>
+                    <consequence>Dersom kravene ikke oppfylles kan det blir vanskeligere å gjenbruke eksisterende saker og journalposter som presedenser. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.2.26 (V): Det skal være mulig å opprette en presedens knyttet til
-                                en sak eller en journalpost
-                            </requirementText>
+                            <requirementText>NOARK 6.2.26 (V): Det skal være mulig å opprette en presedens knyttet til en sak eller en journalpost </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 6.2.27 (V): Det bør være mulig å opprette et register over hvilke
-                                verdier man skal kunne velge presedensHjemmel fra.
-                            </requirementText>
+                            <requirementText>NOARK 6.2.27 (V): Det bør være mulig å opprette et register over hvilke verdier man skal kunne velge presedensHjemmel fra. </requirementText>
                             <priority>2</priority>
                         </requirement>
                     </requirements>
@@ -1257,79 +847,52 @@
                 <section>
                     <sectionOrder>12</sectionOrder>
                     <sectionTitle>Krav til masseimport utløst fra NOARK5-kjerne</sectionTitle>
-                    <description>Kravene sikrer muligheten til å importere flere dokumenter i en og samme sekvens til
-                        løsningen
-                    </description>
-                    <explanation>Moderne saksbehandling forventer at arkivsystemene er fleksible og effektive på
-                        dokumentfangst. Et eksempel på dette er muligheten til å importere dokumenter fra en historisk
-                        base fra et annet Noark system eller et fagsystem.
-                    </explanation>
-                    <consequence>Dersom kravene ikke oppfylles kan løsningen bli et hinder for effektiv
-                        dokumentfangst.
-                    </consequence>
+                    <description>Kravene sikrer muligheten til å importere flere dokumenter i en og samme sekvens til løsningen </description>
+                    <explanation>Moderne saksbehandling forventer at arkivsystemene er fleksible og effektive på dokumentfangst. Et eksempel på dette er muligheten til å importere dokumenter fra en historisk base fra et annet Noark system eller et fagsystem. </explanation>
+                    <consequence>Dersom kravene ikke oppfylles kan løsningen bli et hinder for effektiv dokumentfangst. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.3.9 (V) Noark 5-løsningen skal inneholde masseimportfunksjonalitet
-                                som henter dokumenter fra en angitt plassering og knytte disse til klasser, mapper,
-                                registreringer eller dokumentbeskrivelser.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.9 (V) Noark 5-løsningen skal inneholde masseimportfunksjonalitet som henter dokumenter fra en angitt plassering og knytte disse til klasser, mapper, registreringer eller dokumentbeskrivelser. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 6.3.10 (V): Ved masseimport skal det være mulig å velge om alle
-                                importerte dokumenter skal knyttes til én og samme arkivenhet på samme nivå i
-                                arkivstrukturen eller om hvert enkelt dokument skal knyttes til forskjellige
-                                arkivenheter i arkivstrukturen.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.10 (V): Ved masseimport skal det være mulig å velge om alle importerte dokumenter skal knyttes til én og samme arkivenhet på samme nivå i arkivstrukturen eller om hvert enkelt dokument skal knyttes til forskjellige arkivenheter i arkivstrukturen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 6.3.11 (V): Ved masseimport skal det være mulig å knytte importerte
-                                dokumenter til en allerede eksisterende klasse, mappe, registrering eller
-                                dokumentbeskrivelse.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.11 (V): Ved masseimport skal det være mulig å knytte importerte dokumenter til en allerede eksisterende klasse, mappe, registrering eller dokumentbeskrivelse. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 6.3.12 (V): Ved masseimport skal det være mulig å definere og utfylle
-                                metadatasettet for dokumentene som skal importeres, kun én gang.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.12 (V): Ved masseimport skal det være mulig å definere og utfylle metadatasettet for dokumentene som skal importeres, kun én gang. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 6.3.13 (V): Noark 5-kjernen skal ha automatikk for å fange dokumenter
-                                som er generert og overført fra andre system.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.13 (V): Noark 5-kjernen skal ha automatikk for å fange dokumenter som er generert og overført fra andre system. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 6.3.14 (V): Noark 5-kjernen skal ha mulighet til å håndtere inputkø
-                                ved masseimport. Merknad: For håndtering av inputkøen kan det for eksempel være ønskelig
-                                å se køene, pause en eller flere køer, starte en eller alle køene på nytt, slette en kø.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.14 (V): Noark 5-kjernen skal ha mulighet til å håndtere inputkø ved masseimport. Merknad: For håndtering av inputkøen kan det for eksempel være ønskelig å se køene, pause en eller flere køer, starte en eller alle køene på nytt, slette en kø. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 6.3.15 (V): Noark 5-kjernen skal kunne fange metadata knyttet til
-                                alle dokumentene som overføres, automatisk. Det skal være mulig å overstyre dette ved
-                                manglede eller feil metadata.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.15 (V): Noark 5-kjernen skal kunne fange metadata knyttet til alle dokumentene som overføres, automatisk. Det skal være mulig å overstyre dette ved manglede eller feil metadata. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -1337,35 +900,22 @@
                 <section>
                     <sectionOrder>13</sectionOrder>
                     <sectionTitle>Krav til elektroniske skjema for utfylling over internett</sectionTitle>
-                    <description>Kravene sikrer effektiv og korrekt registrering av dokumenter som kommer inn til
-                        organisasjonen som skjemaer fylt ut på internett.
-                    </description>
-                    <explanation>Flere og flere dokumenter blir generert fra skjemaer på internett og det er viktig å
-                        sikre en automatisert dokumentfangst fra slike skjemaer
-                    </explanation>
-                    <consequence>Dersom kravene ikke oppfylles vil organisasjonen måtte behandle dokumenter fra skjemaer
-                        manuelt.
-                    </consequence>
+                    <description>Kravene sikrer effektiv og korrekt registrering av dokumenter som kommer inn til organisasjonen som skjemaer fylt ut på internett. </description>
+                    <explanation>Flere og flere dokumenter blir generert fra skjemaer på internett og det er viktig å sikre en automatisert dokumentfangst fra slike skjemaer </explanation>
+                    <consequence>Dersom kravene ikke oppfylles vil organisasjonen måtte behandle dokumenter fra skjemaer manuelt. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.3.20 (V) Det bør finnes funksjonalitet for å hente inn både
-                                relevante svardata og transaksjonsopplysninger fra elektroniske skjemaer, og legge disse
-                                inn som mappe, registrering, dokumentbeskrivelse og dokument i en automatisert prosess.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.20 (V) Det bør finnes funksjonalitet for å hente inn både relevante svardata og transaksjonsopplysninger fra elektroniske skjemaer, og legge disse inn som mappe, registrering, dokumentbeskrivelse og dokument i en automatisert prosess. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 6.3.25 (V) For dynamiske skjemaer bør informasjon om aktuell versjon
-                                av skjema og presentasjonsprogramvare lagres sammen med eller som del av
-                                resultatdatasettet, innfelt i den skjemaversjonen som ble brukt ved utfylling av
-                                skjemaet.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.25 (V) For dynamiske skjemaer bør informasjon om aktuell versjon av skjema og presentasjonsprogramvare lagres sammen med eller som del av resultatdatasettet, innfelt i den skjemaversjonen som ble brukt ved utfylling av skjemaet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -1373,33 +923,22 @@
                 <section>
                     <sectionOrder>14</sectionOrder>
                     <sectionTitle>Krav til elektronisk dokumentutveksling Pri</sectionTitle>
-                    <description>Kravene sikrer en automatisert måte å utveksle dokumenter mellom elektroniske løsninger
-                        (Noark) internt i organisasjonen og mellom ulike forvaltningsorganer.
-                    </description>
-                    <explanation>Målene med eForvaltning krever en smidig dokumentutveksling og det er viktig at det
-                        finnes automatiserte metoder for å sikre slik utveksling. Dette må skje på en måte som ivaretar
-                        arkivfaglige hensyn.
-                    </explanation>
-                    <consequence>Dersom kravene ikke oppfylles vil dette føre til manuelt håndtering av slik
-                        korrespondanse.
-                    </consequence>
+                    <description>Kravene sikrer en automatisert måte å utveksle dokumenter mellom elektroniske løsninger (Noark) internt i organisasjonen og mellom ulike forvaltningsorganer. </description>
+                    <explanation>Målene med eForvaltning krever en smidig dokumentutveksling og det er viktig at det finnes automatiserte metoder for å sikre slik utveksling. Dette må skje på en måte som ivaretar arkivfaglige hensyn. </explanation>
+                    <consequence>Dersom kravene ikke oppfylles vil dette føre til manuelt håndtering av slik korrespondanse. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.3.26 (V) Det skal finnes funksjoner for sikker, automatisert
-                                dokumentutveksling mellom Noark-løsninger, basert på XML-skjema for dokumentutveksling.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.26 (V) Det skal finnes funksjoner for sikker, automatisert dokumentutveksling mellom Noark-løsninger, basert på XML-skjema for dokumentutveksling. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>Det skal være mulig å sende og motta krypterte dokumenter. Leverandøren
-                                skal beskrive hvordan løsningen ivaretar dette.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å sende og motta krypterte dokumenter. Leverandøren skal beskrive hvordan løsningen ivaretar dette. </requirementText>
                             <priority>1 (i)</priority>
                         </requirement>
                     </requirements>
@@ -1407,43 +946,28 @@
                 <section>
                     <sectionOrder>15</sectionOrder>
                     <sectionTitle>Krav til migrering mellom NOARK-løsninger</sectionTitle>
-                    <description>Kravene sikrer muligheten til å importere dokumenter skapt med et Noark struktur kan
-                        importeres inn i løsningen.
-                    </description>
-                    <explanation>Ved innkjøp av et nytt system kan det kostnadsreduserende hvis den nye løsningen kan
-                        importere et fullstendig uttrekk fra det gamle systemet. Samtidig kan muligheten til å importere
-                        et komplett uttrekk også brukes som et testverktøy for å sjekke at løsningen er i henhold til
-                        Noark 5 standarden.
-                    </explanation>
-                    <consequence>Dersom kravene ikke oppfylles vil det være vanskeligere å importere data produsert i en
-                        Noark struktur. Det kan medføre en økonomisk konsekvens for eksempel ved bytte av
-                        systemleverandør
-                    </consequence>
+                    <description>Kravene sikrer muligheten til å importere dokumenter skapt med et Noark struktur kan importeres inn i løsningen. </description>
+                    <explanation>Ved innkjøp av et nytt system kan det kostnadsreduserende hvis den nye løsningen kan importere et fullstendig uttrekk fra det gamle systemet. Samtidig kan muligheten til å importere et komplett uttrekk også brukes som et testverktøy for å sjekke at løsningen er i henhold til Noark 5 standarden. </explanation>
+                    <consequence>Dersom kravene ikke oppfylles vil det være vanskeligere å importere data produsert i en Noark struktur. Det kan medføre en økonomisk konsekvens for eksempel ved bytte av systemleverandør </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.3.33 (V) Det skal være mulig å importere alle metadata som er
-                                definert i denne standarden med tilhørende dokumenter basert på avleveringsformatet.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.33 (V) Det skal være mulig å importere alle metadata som er definert i denne standarden med tilhørende dokumenter basert på avleveringsformatet. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 6.3.34 (V): Det skal være mulig å eksportere deler av
-                                arkivstrukturen, f.eks. en arkivdel eller en klasse.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.34 (V): Det skal være mulig å eksportere deler av arkivstrukturen, f.eks. en arkivdel eller en klasse. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 6.3.35 (V): Det skal være mulig å importere deler av arkivstrukturen,
-                                f.eks. en arkivdel eller en klasse.
-                            </requirementText>
+                            <requirementText>NOARK 6.3.35 (V): Det skal være mulig å importere deler av arkivstrukturen, f.eks. en arkivdel eller en klasse. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -1451,57 +975,40 @@
                 <section>
                     <sectionOrder>16</sectionOrder>
                     <sectionTitle>Krav til tilgjengeliggjøring av offentlig journal på internett</sectionTitle>
-                    <description>Kravene sikrer muligheten til å legge organisasjonens postjournal tilgjengelig på
-                        internett.
-                    </description>
-                    <explanation>Publisering av offentlig journal er et viktig ledd i åpenhet om demokratiet. En del
-                        forvaltningsorganer er pålagt å publisere sin postjournal på internett, mens for andre organer
-                        er det en sterk forventning fra samfunnet at slik publisering skjer.
-                    </explanation>
-                    <consequence>Dersom kravene ikke oppfylles vil det ikke være mulig å publisere offentlig journal.
-                    </consequence>
+                    <description>Kravene sikrer muligheten til å legge organisasjonens postjournal tilgjengelig på internett. </description>
+                    <explanation>Publisering av offentlig journal er et viktig ledd i åpenhet om demokratiet. En del forvaltningsorganer er pålagt å publisere sin postjournal på internett, mens for andre organer er det en sterk forventning fra samfunnet at slik publisering skjer. </explanation>
+                    <consequence>Dersom kravene ikke oppfylles vil det ikke være mulig å publisere offentlig journal. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.5.40 (V) Det skal være mulig å eksportere uttrekk for
-                                tilgjengeliggjøring av offentlig journal.
-                            </requirementText>
+                            <requirementText>NOARK 6.5.40 (V) Det skal være mulig å eksportere uttrekk for tilgjengeliggjøring av offentlig journal. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 6.5.46 (V) Personnavn som tilgjengelig gjøres direkte på en webside
-                                skal merkes for utelukking fra indeksering av indekseringstjenester.
-                            </requirementText>
+                            <requirementText>NOARK 6.5.46 (V) Personnavn som tilgjengelig gjøres direkte på en webside skal merkes for utelukking fra indeksering av indekseringstjenester. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 6.5.48 (V) Personnavn bør merkes med XML-taggene &lt;personnavn&gt;
-                                &lt;/personnavn&gt; før de eksporteres.
-                            </requirementText>
+                            <requirementText>NOARK 6.5.48 (V) Personnavn bør merkes med XML-taggene &lt;personnavn&gt; &lt;/personnavn&gt; før de eksporteres. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 6.4.49 (V) Det skal være mulig å tilgjengelig gjøre arkivdokumenter
-                                knyttet til de enkelte journalpostene i offentlig journal på Internett.
-                            </requirementText>
+                            <requirementText>NOARK 6.4.49 (V) Det skal være mulig å tilgjengelig gjøre arkivdokumenter knyttet til de enkelte journalpostene i offentlig journal på Internett. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 6.5.52 (V) Tilgjengeliggjøring av offentlig journal og eventuelle
-                                arkivdokumenter på Internett skal etableres med hindre mot automatisert indeksering fra
-                                eksterne aktører, f.eks. søkemotorer.
-                            </requirementText>
+                            <requirementText>NOARK 6.5.52 (V) Tilgjengeliggjøring av offentlig journal og eventuelle arkivdokumenter på Internett skal etableres med hindre mot automatisert indeksering fra eksterne aktører, f.eks. søkemotorer. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -1510,30 +1017,21 @@
                     <sectionOrder>17</sectionOrder>
                     <sectionTitle>Krav til sikkerhetskonfigurasjon</sectionTitle>
                     <description>Kravet sikrer kunden en beskrivelse av systemets sikkerhetskonfigurasjon.</description>
-                    <explanation>Det vil ofte være ønskelig med integrasjon med eksterne systemer feks en skanner og det
-                        er viktig at den faktiske brukeren som skanner et dokument er identifisert ikke bare skanneren.
-                    </explanation>
-                    <consequence>Hvis sikkerhetskonfigurasjonen ikke er tilstrekkelig god vil det kunne gjøres endringer
-                        i arkivdatabasen uten at det er logget eller sporbart hvem som har foretatt endringene.
-                    </consequence>
+                    <explanation>Det vil ofte være ønskelig med integrasjon med eksterne systemer feks en skanner og det er viktig at den faktiske brukeren som skanner et dokument er identifisert ikke bare skanneren. </explanation>
+                    <consequence>Hvis sikkerhetskonfigurasjonen ikke er tilstrekkelig god vil det kunne gjøres endringer i arkivdatabasen uten at det er logget eller sporbart hvem som har foretatt endringene. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.6.8 (V) Det bør kunne brukes andre og sterkere autentiseringsmåter
-                                som alternativ til passord
-                            </requirementText>
+                            <requirementText>NOARK 6.6.8 (V) Det bør kunne brukes andre og sterkere autentiseringsmåter som alternativ til passord </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>Leverandøren bes beskrive hvordan brukerinteraksjon via en ekstern modul
-                                skjer og hvorvidt hendelser kan knyttes til den faktiske brukeren og ikke bare knyttes
-                                til modulens identifikasjon.
-                            </requirementText>
+                            <requirementText>Leverandøren bes beskrive hvordan brukerinteraksjon via en ekstern modul skjer og hvorvidt hendelser kan knyttes til den faktiske brukeren og ikke bare knyttes til modulens identifikasjon. </requirementText>
                             <priority>O (i)</priority>
                         </requirement>
                     </requirements>
@@ -1541,34 +1039,22 @@
                 <section>
                     <sectionOrder>18</sectionOrder>
                     <sectionTitle>Krav til rettighetsangivelser</sectionTitle>
-                    <description>Kravet sikrer et nivå av autorisasjon på forskjellige objekter i arkivbasen
-                    </description>
-                    <explanation>Det kan være ønskelig å begrense tilgang til objekter i arkivbasen der autorisasjon er
-                        definert på brukernivå. Et eksempel på dette kan være en personalmappe der det er behov for å gi
-                        spesielle rettigheter.
-                    </explanation>
-                    <consequence>Dersom kravene ikke finnes kan det bli vanskelig å gi riktig tilgangskontroll. Dette
-                        vil føre til en vanskeligere og mindre fleksibel arkivering.
-                    </consequence>
+                    <description>Kravet sikrer et nivå av autorisasjon på forskjellige objekter i arkivbasen </description>
+                    <explanation>Det kan være ønskelig å begrense tilgang til objekter i arkivbasen der autorisasjon er definert på brukernivå. Et eksempel på dette kan være en personalmappe der det er behov for å gi spesielle rettigheter. </explanation>
+                    <consequence>Dersom kravene ikke finnes kan det bli vanskelig å gi riktig tilgangskontroll. Dette vil føre til en vanskeligere og mindre fleksibel arkivering. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.6.18 (V) For hver arkivdel, klasse, mappe,registrering og
-                                dokumentbeskrivelse bør det kunne registreres hvilke personlig identifiserte brukere som
-                                har lesetilgang
-                            </requirementText>
+                            <requirementText>NOARK 6.6.18 (V) For hver arkivdel, klasse, mappe,registrering og dokumentbeskrivelse bør det kunne registreres hvilke personlig identifiserte brukere som har lesetilgang </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 6.6.19 (V) For hver arkivdel, klasse, mappe, registrering og
-                                dokumentbeskrivelse bør det kunne registreres hvilke personlig identifiserte brukere som
-                                har oppdateringstilgang
-                            </requirementText>
+                            <requirementText>NOARK 6.6.19 (V) For hver arkivdel, klasse, mappe, registrering og dokumentbeskrivelse bør det kunne registreres hvilke personlig identifiserte brukere som har oppdateringstilgang </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -1576,12 +1062,8 @@
                 <section>
                     <sectionOrder>19</sectionOrder>
                     <sectionTitle>Krav til skjerming og gradering</sectionTitle>
-                    <description>Dette kapittelet omhandler skjerming av arkivdel, klasse, sak, registrering
-                        (journalpost) og dokument med vedlegg.
-                    </description>
-                    <explanation>Man skal kunne skjerme en arkivdel - eks. Barnemappe -, en klasse, tittel på sak og
-                        registrering samt dokumenter og/eller vedlegg.
-                    </explanation>
+                    <description>Dette kapittelet omhandler skjerming av arkivdel, klasse, sak, registrering (journalpost) og dokument med vedlegg. </description>
+                    <explanation>Man skal kunne skjerme en arkivdel - eks. Barnemappe -, en klasse, tittel på sak og registrering samt dokumenter og/eller vedlegg. </explanation>
                     <consequence>Kun autoriserte brukere får innsyn i informasjonen som er registrert.</consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
@@ -1589,64 +1071,43 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.6.26 (V) Skjerming bør kunne arves til mappe, journalpost,
-                                dokumentbeskrivelse og dokumentobjekt. Arvede verdier skal kunne overstyres.
-                            </requirementText>
+                            <requirementText>NOARK 6.6.26 (V) Skjerming bør kunne arves til mappe, journalpost, dokumentbeskrivelse og dokumentobjekt. Arvede verdier skal kunne overstyres. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 6.6.27 (V) Skjerming av Klasse bør kunne arves til mappe,
-                                journalpost, dokumentbeskrivelse og dokumentobjekt.Arvede verdier skal kunne overstyres
-                            </requirementText>
+                            <requirementText>NOARK 6.6.27 (V) Skjerming av Klasse bør kunne arves til mappe, journalpost, dokumentbeskrivelse og dokumentobjekt.Arvede verdier skal kunne overstyres </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 6.6.41 og 12.3.2 (V): Dersom tilgangskoden er merket med indikasjon
-                                på at det bare er anledning til å unnta visse opplysninger i dokumentet fra innsyn, kan
-                                det opprettes en «offentlig variant» av dokumentet der disse opplysningene ikke finnes,
-                                som derfor kan unntas fra skjerming
-                            </requirementText>
+                            <requirementText>NOARK 6.6.41 og 12.3.2 (V): Dersom tilgangskoden er merket med indikasjon på at det bare er anledning til å unnta visse opplysninger i dokumentet fra innsyn, kan det opprettes en «offentlig variant» av dokumentet der disse opplysningene ikke finnes, som derfor kan unntas fra skjerming </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 12.3.1 (V): Det skal synliggjøres i journalen om en registrering med
-                                en tilgangskode inneholder ett eller flere dokumenter som ikke er merket med
-                                tilgangskode
-                            </requirementText>
+                            <requirementText>NOARK 12.3.1 (V): Det skal synliggjøres i journalen om en registrering med en tilgangskode inneholder ett eller flere dokumenter som ikke er merket med tilgangskode </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 12.3.3 (V): Løsningen skal vise hvilke opplysningstyper som er angitt
-                                at skal skjermes. Det at en gitt opplysning er avkrysset for skjerming skal vises både
-                                for de som har tilgang til å se de skjermede opplysningene og for de som ikke har
-                                tilgang til å se dem
-                            </requirementText>
+                            <requirementText>NOARK 12.3.3 (V): Løsningen skal vise hvilke opplysningstyper som er angitt at skal skjermes. Det at en gitt opplysning er avkrysset for skjerming skal vises både for de som har tilgang til å se de skjermede opplysningene og for de som ikke har tilgang til å se dem </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 12.3.4 (V): Dokumentbeskrivelsen skal arve registreringens
-                                tilgangskode som standardverdi, dersom ikke dokumentbeskrivelsen har tilgangskode fra
-                                før, og dersom den ikke fra før er tilknyttet en annen registrering
-                            </requirementText>
+                            <requirementText>NOARK 12.3.4 (V): Dokumentbeskrivelsen skal arve registreringens tilgangskode som standardverdi, dersom ikke dokumentbeskrivelsen har tilgangskode fra før, og dersom den ikke fra før er tilknyttet en annen registrering </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>Dersom det skjer endringer av graderingsangivelser på journalopplysninger
-                                eller filer, skal løsningen gi en påminning om å endre gradering på tilknyttede journal
-                                opplysninger/filer.
-                            </requirementText>
+                            <requirementText>Dersom det skjer endringer av graderingsangivelser på journalopplysninger eller filer, skal løsningen gi en påminning om å endre gradering på tilknyttede journal opplysninger/filer. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -1654,78 +1115,52 @@
                 <section>
                     <sectionOrder>20</sectionOrder>
                     <sectionTitle>Krav knyttet til arkivformat og dokumentformat</sectionTitle>
-                    <description>Her beskrives hvordan systemet skal forholde seg til ulike filformater samt automatisk
-                        eller manuell konvertering til arkivformat.
-                    </description>
-                    <explanation>Det skal være mulig å definere filformater som en organisasjon benytter selv, samt
-                        mottar. Egenproduserte filformat skal automatisk konverteres til arkivformat ved angivelse av
-                        status.
-                    </explanation>
-                    <consequence>Ved å ikke definere dette kravet, vil ikke definerte filformat ikke kunne importeres
-                        eller produseres, og konvertering til godkjent filformat ikke skje automatisk.
-                    </consequence>
+                    <description>Her beskrives hvordan systemet skal forholde seg til ulike filformater samt automatisk eller manuell konvertering til arkivformat. </description>
+                    <explanation>Det skal være mulig å definere filformater som en organisasjon benytter selv, samt mottar. Egenproduserte filformat skal automatisk konverteres til arkivformat ved angivelse av status. </explanation>
+                    <consequence>Ved å ikke definere dette kravet, vil ikke definerte filformat ikke kunne importeres eller produseres, og konvertering til godkjent filformat ikke skje automatisk. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>Alle egenproduserte og importerte filer skal automatisk konverteres til det
-                                til enhver tid godkjente arkivformatet. Konvertering skal skje i sammenheng med
-                                angivelse av status.
-                            </requirementText>
+                            <requirementText>Alle egenproduserte og importerte filer skal automatisk konverteres til det til enhver tid godkjente arkivformatet. Konvertering skal skje i sammenheng med angivelse av status. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>Det skal i tillegg til automatisk fortløpende konvertering være mulig for
-                                brukeren å konvertere filer til godkjent arkivformat både manuelt for en og en fil og
-                                samlet for et definert sett av filer som av en eller annen årsak ikke har blitt
-                                konvertert
-                            </requirementText>
+                            <requirementText>Det skal i tillegg til automatisk fortløpende konvertering være mulig for brukeren å konvertere filer til godkjent arkivformat både manuelt for en og en fil og samlet for et definert sett av filer som av en eller annen årsak ikke har blitt konvertert </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>Alle arkiverte dokumenter skal finnes i produksjonsformat, også etter at
-                                arkivformat er generert.
-                            </requirementText>
+                            <requirementText>Alle arkiverte dokumenter skal finnes i produksjonsformat, også etter at arkivformat er generert. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>Produksjonsformatet pekt på i kravet over skal være enkelt tilgjengelig for
-                                saksbehandler slik at tekst kan gjenbrukes eller produksjonsformatet kan benyttes til å
-                                opprette nye versjoner av dokumentet.
-                            </requirementText>
+                            <requirementText>Produksjonsformatet pekt på i kravet over skal være enkelt tilgjengelig for saksbehandler slik at tekst kan gjenbrukes eller produksjonsformatet kan benyttes til å opprette nye versjoner av dokumentet. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>Dersom godkjent arkivformat endres skal leverandøren sørge for at løsningen
-                                på en enkel måte håndterer konvertering av filer på tidligere godkjent format til nytt
-                                godkjent arkivformat. Med enkelt menes en form for masseoppdatering.
-                            </requirementText>
+                            <requirementText>Dersom godkjent arkivformat endres skal leverandøren sørge for at løsningen på en enkel måte håndterer konvertering av filer på tidligere godkjent format til nytt godkjent arkivformat. Med enkelt menes en form for masseoppdatering. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>Løsningen skal ha funksjonalitet for å lagre kartdata både på ascii og
-                                binær form
-                            </requirementText>
+                            <requirementText>Løsningen skal ha funksjonalitet for å lagre kartdata både på ascii og binær form </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>Løsningen skal ha funksjonalitet for å lagre lydfiler, bildefiler og
-                                multimediafiler.
-                            </requirementText>
+                            <requirementText>Løsningen skal ha funksjonalitet for å lagre lydfiler, bildefiler og multimediafiler. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -1733,12 +1168,8 @@
                 <section>
                     <sectionOrder>21</sectionOrder>
                     <sectionTitle>Krav knyttet til masseoppdatering</sectionTitle>
-                    <description>Denne funksjonaliteten er ønsket der man har behov for å gjøre større endringer i mange
-                        saker eller journalposter samtidig.
-                    </description>
-                    <explanation>Ved endring av saksbehandler, status, koder, skjerming, klassering er det ønskelig å
-                        kunne gjøre dette i en og samme operasjon.
-                    </explanation>
+                    <description>Denne funksjonaliteten er ønsket der man har behov for å gjøre større endringer i mange saker eller journalposter samtidig. </description>
+                    <explanation>Ved endring av saksbehandler, status, koder, skjerming, klassering er det ønskelig å kunne gjøre dette i en og samme operasjon. </explanation>
                     <consequence>Praktisk og tidsbesparende løsning.</consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
@@ -1746,43 +1177,31 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>I noen tilfeller er det ønskelig å kunne gjøre endringer i mange saker
-                                eller journalposter samtidig. Løsningen skal ha mulighet for at arkivarene kan gjøre
-                                slike endringer. Endringene gjelder typisk elementer som; status, saksbehandler,
-                                arkivkode, enhet, arkivdel, klassering, unntakshjemler, skjermingsregler og
-                                bevarings-/kassasjonsregler.
-                            </requirementText>
+                            <requirementText>I noen tilfeller er det ønskelig å kunne gjøre endringer i mange saker eller journalposter samtidig. Løsningen skal ha mulighet for at arkivarene kan gjøre slike endringer. Endringene gjelder typisk elementer som; status, saksbehandler, arkivkode, enhet, arkivdel, klassering, unntakshjemler, skjermingsregler og bevarings-/kassasjonsregler. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>Ved masseendring skal endringene som vil foretas ved endring vises visuelt
-                                før endringene gjøres, slik at brukeren kan verifisere endringene før kjøring.
-                            </requirementText>
+                            <requirementText>Ved masseendring skal endringene som vil foretas ved endring vises visuelt før endringene gjøres, slik at brukeren kan verifisere endringene før kjøring. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>Løsningen skal ha funksjoner for masseavskrivning og masseavslutning av
-                                saker og journalposter. Funksjonen skal være rettighetsstyrt.
-                            </requirementText>
+                            <requirementText>Løsningen skal ha funksjoner for masseavskrivning og masseavslutning av saker og journalposter. Funksjonen skal være rettighetsstyrt. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>Det skal være mulig å endre saksbehandler på mange saker i én operasjon,
-                                dvs. endre til én ny saksbehandler.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å endre saksbehandler på mange saker i én operasjon, dvs. endre til én ny saksbehandler. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>Oppdatering av K-koder skal være inkludert i tilbudt løsning.
-                            </requirementText>
+                            <requirementText>Oppdatering av K-koder skal være inkludert i tilbudt løsning. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -1791,61 +1210,40 @@
             <section>
                 <sectionOrder>6</sectionOrder>
                 <sectionTitle>Krav til adresseregister</sectionTitle>
-                <description>Det skal være funksjonalitet for opprettelse av et adresseregister for hele organisasjonen,
-                    for oppslag av både eksterne og interne adressater.
-                </description>
-                <explanation>Ved å etablere denne funksjonaliteten vil alle saksbehandlere kunne benytte samme register.
-                    Alle adressater bør være registrert med epostadresse. Det skal samtidig være mulig å registrere en
-                    adressat i en journalpost uten at denne er forhåndsdefinert i adresseregisteret. Administrasjon av
-                    organisasjonens adresseregister bør tillegges autoriserte brukere.
-                </explanation>
-                <consequence>Hvis man ikke benytter adresseregister vil man få ulike skrivemåter på adressater,
-                    ikke-offisielle epostadressater i stedet for organisasjoners postmottak osv. Et adresseregister
-                    “uniformerer” adressater
-                </consequence>
+                <description>Det skal være funksjonalitet for opprettelse av et adresseregister for hele organisasjonen, for oppslag av både eksterne og interne adressater. </description>
+                <explanation>Ved å etablere denne funksjonaliteten vil alle saksbehandlere kunne benytte samme register. Alle adressater bør være registrert med epostadresse. Det skal samtidig være mulig å registrere en adressat i en journalpost uten at denne er forhåndsdefinert i adresseregisteret. Administrasjon av organisasjonens adresseregister bør tillegges autoriserte brukere. </explanation>
+                <consequence>Hvis man ikke benytter adresseregister vil man få ulike skrivemåter på adressater, ikke-offisielle epostadressater i stedet for organisasjoners postmottak osv. Et adresseregister “uniformerer” adressater </consequence>
                 <type>submenu</type>
                 <showMe>true</showMe>
                 <requirements>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>NOARK 7.1.1 (V): Det skal finnes funksjoner for å etablere et register med navn
-                            og adresser til korrespondansepartnere (adresseregister), og dette skal kunne benyttes til
-                            oppslag ved registrering av avsendere, mottakere og parter i en sak.
-                        </requirementText>
+                        <requirementText>NOARK 7.1.1 (V): Det skal finnes funksjoner for å etablere et register med navn og adresser til korrespondansepartnere (adresseregister), og dette skal kunne benyttes til oppslag ved registrering av avsendere, mottakere og parter i en sak. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Det skal ikke være mulig å opprette sideordnede eller underordnede
-                            adresseregistre. Dersom dette likevel er mulig, skal funksjonen være rettighetsstyrt.
-                        </requirementText>
+                        <requirementText>Det skal ikke være mulig å opprette sideordnede eller underordnede adresseregistre. Dersom dette likevel er mulig, skal funksjonen være rettighetsstyrt. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Det skal være enkelt å registrere avsender / mottaker på journalposter uten at
-                            disse finnes/må finnes i adresseregisteret.
-                        </requirementText>
+                        <requirementText>Det skal være enkelt å registrere avsender / mottaker på journalposter uten at disse finnes/må finnes i adresseregisteret. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>Adresseregisteret skal kunne inneholde e-postadresser, og det må ved sending av
-                            e-post fra løsningen være enkelt å hente opp e-postadresser fra adresseregisteret.
-                        </requirementText>
+                        <requirementText>Adresseregisteret skal kunne inneholde e-postadresser, og det må ved sending av e-post fra løsningen være enkelt å hente opp e-postadresser fra adresseregisteret. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Når en kontakt er registrert på en journalpost (uten å være registrert i
-                            adresseregisteret) skal det være enkelt å overføre de registrerte opplysningene fra
-                            journalposten til adresseregisteret.
-                        </requirementText>
+                        <requirementText>Når en kontakt er registrert på en journalpost (uten å være registrert i adresseregisteret) skal det være enkelt å overføre de registrerte opplysningene fra journalposten til adresseregisteret. </requirementText>
                         <priority>1</priority>
                     </requirement>
                 </requirements>
@@ -1858,26 +1256,16 @@
                 <section>
                     <sectionOrder>1</sectionOrder>
                     <sectionTitle>Krav til saksoppfølging</sectionTitle>
-                    <description>Hvis man ikke benytter adresseregister vil man få ulike skrivemåter på adressater,
-                        ikke-offisielle epostadressater i stedet for organisasjoners postmottak osv. Et adresseregister
-                        “uniformerer” adressater.
-                    </description>
-                    <explanation>Det er viktig at systemet kan gi oversikt over behandlingsfrister på en brukerdefinert
-                        måte.
-                    </explanation>
-                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig, vil dette kunne gå ut over
-                        organisasjonens evne til å kvalitetssikre arkivdanningen og saksbehandlingen. Det kan også i
-                        gitte tilfeller få økonomiske konsekvenser.
-                    </consequence>
+                    <description>Hvis man ikke benytter adresseregister vil man få ulike skrivemåter på adressater, ikke-offisielle epostadressater i stedet for organisasjoners postmottak osv. Et adresseregister “uniformerer” adressater. </description>
+                    <explanation>Det er viktig at systemet kan gi oversikt over behandlingsfrister på en brukerdefinert måte. </explanation>
+                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig, vil dette kunne gå ut over organisasjonens evne til å kvalitetssikre arkivdanningen og saksbehandlingen. Det kan også i gitte tilfeller få økonomiske konsekvenser. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 7.2.1 (V): Det skal finnes funksjoner for å hente fram eksterne og
-                                interne dokumenter fra journalposter som har behandlingsfrist i et angitt tidsrom.
-                            </requirementText>
+                            <requirementText>NOARK 7.2.1 (V): Det skal finnes funksjoner for å hente fram eksterne og interne dokumenter fra journalposter som har behandlingsfrist i et angitt tidsrom. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -1886,180 +1274,123 @@
                     <sectionOrder>2</sectionOrder>
                     <sectionTitle>Krav til dokumentproduksjon</sectionTitle>
                     <description>Disse kravene letter dokumentproduksjonen for organisasjonen.</description>
-                    <explanation>Kapittelet omhandler i første rekke krav som styrer hvordan dokumentproduksjonen
-                        styres. Det er derfor viktig at organisasjonen vurderer hvert enkelt krav nøye med hensyn til
-                        hvilken prioritering man ønsker.
-                    </explanation>
-                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig i løsningen, kan det ha konsekvenser for
-                        fleksibiliteten i saksbehandlingen.
-                    </consequence>
+                    <explanation>Kapittelet omhandler i første rekke krav som styrer hvordan dokumentproduksjonen styres. Det er derfor viktig at organisasjonen vurderer hvert enkelt krav nøye med hensyn til hvilken prioritering man ønsker. </explanation>
+                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig i løsningen, kan det ha konsekvenser for fleksibiliteten i saksbehandlingen. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 7.3.1 (V): Det skal være mulig for flere personer å utarbeide og
-                                redigere et stort dokument samtidig
-                            </requirementText>
+                            <requirementText>NOARK 7.3.1 (V): Det skal være mulig for flere personer å utarbeide og redigere et stort dokument samtidig </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 7.3.2 (V): Det skal være mulig å opprette dokument og dokumentmaler
-                                som fritt skal kunne defineres og seksjoneres i forskjellige deler til ulike
-                                brukere/forfattere
-                            </requirementText>
+                            <requirementText>NOARK 7.3.2 (V): Det skal være mulig å opprette dokument og dokumentmaler som fritt skal kunne defineres og seksjoneres i forskjellige deler til ulike brukere/forfattere </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 7.3.4 (V): Den som oppretter et dokument, dokumenteieren, bør ha
-                                rettigheter til å dele opp dokumentet i seksjoner og tildele lese-, kommentar-,remiss-
-                                og skriverettigheter til de enkelte seksjonene.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.4 (V): Den som oppretter et dokument, dokumenteieren, bør ha rettigheter til å dele opp dokumentet i seksjoner og tildele lese-, kommentar-,remiss- og skriverettigheter til de enkelte seksjonene. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 7.3.7 (V): Dokumenteier skal kunne tildele annen bruker rollen som
-                                dokument- og seksjonseier.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.7 (V): Dokumenteier skal kunne tildele annen bruker rollen som dokument- og seksjonseier. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 7.3.8 (V): For personer som har kommentar-rettigheter til et dokument
-                                eller seksjon, men ikke skriverettigheter, skal det være mulig å knytte kommentarnotater
-                                til dokumentet. Det skal enkelt kunne identifiseres hvilken del av teksten som er
-                                kommentert og hvem som har gjort det.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.8 (V): For personer som har kommentar-rettigheter til et dokument eller seksjon, men ikke skriverettigheter, skal det være mulig å knytte kommentarnotater til dokumentet. Det skal enkelt kunne identifiseres hvilken del av teksten som er kommentert og hvem som har gjort det. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 7.3.9 (V): For hver seksjon skal dokumenteier kunne tildele lese-,
-                                kommentar-, remiss- og eventuelt skriverettigheter til en enhet/avdeling, en definert
-                                rolle eller en definert bruker, heretter som en fellesbenevnelse benevnt «bruker».
-                            </requirementText>
+                            <requirementText>NOARK 7.3.9 (V): For hver seksjon skal dokumenteier kunne tildele lese-, kommentar-, remiss- og eventuelt skriverettigheter til en enhet/avdeling, en definert rolle eller en definert bruker, heretter som en fellesbenevnelse benevnt «bruker». </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 7.3.10 (V): Ved tildeling av lese- og skrive-rettigheter til en
-                                avdeling, skal alle på avdelingen kunne lese, åpne og skrive/redigere dokumentet eller
-                                seksjonen(e) som er det gitt rettigheter til.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.10 (V): Ved tildeling av lese- og skrive-rettigheter til en avdeling, skal alle på avdelingen kunne lese, åpne og skrive/redigere dokumentet eller seksjonen(e) som er det gitt rettigheter til. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 7.3.11 (V): Ved tildeling av lese- og skrive-rettigheter til en
-                                rolle, skal alle som har rollen kunne lese, åpne og skrive/redigere dokumentet eller
-                                seksjonen(e) som er det gitt rettigheter til.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.11 (V): Ved tildeling av lese- og skrive-rettigheter til en rolle, skal alle som har rollen kunne lese, åpne og skrive/redigere dokumentet eller seksjonen(e) som er det gitt rettigheter til. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>NOARK 7.3.12 (V): Når en bruker har åpnet en seksjon for
-                                skriving/redigering, skal den ikke kunne åpnes av andre, dvs er den låst for lesing og
-                                skriving/redigering av andre.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.12 (V): Når en bruker har åpnet en seksjon for skriving/redigering, skal den ikke kunne åpnes av andre, dvs er den låst for lesing og skriving/redigering av andre. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>NOARK 7.3.16 (V): Seksjoner brukeren ikke har leserettigheter til, skal
-                                fjernes fysisk for brukeren.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.16 (V): Seksjoner brukeren ikke har leserettigheter til, skal fjernes fysisk for brukeren. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>NOARK 7.3.17 (V): Når bruker er ferdig med seksjonen og avslutter den, bør
-                                låsingen oppheves. Alle med leserettigheter bør kunne lese seksjonen og brukere med
-                                skrive-/redigeringsrettigheter bør kunne skrive/redigere i seksjonen.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.17 (V): Når bruker er ferdig med seksjonen og avslutter den, bør låsingen oppheves. Alle med leserettigheter bør kunne lese seksjonen og brukere med skrive-/redigeringsrettigheter bør kunne skrive/redigere i seksjonen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>NOARK 7.3.18 (V): Det skal være mulig ut fra dokumentoversikten å se hvem
-                                som er tildelt, og jobber med et dokument og seksjon.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.18 (V): Det skal være mulig ut fra dokumentoversikten å se hvem som er tildelt, og jobber med et dokument og seksjon. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>13</showOrder>
-                            <requirementText>NOARK 7.3.19 (V): Et seksjonert dokument bør bare kunne leses av den som
-                                har rettigheter til å lese en eller flere seksjoner i dokumentet.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.19 (V): Et seksjonert dokument bør bare kunne leses av den som har rettigheter til å lese en eller flere seksjoner i dokumentet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>14</showOrder>
-                            <requirementText>NOARK 7.3.20 (V): Et seksjonert dokument bør bare kunne åpnes av bruker som
-                                dokumenteier har gitt rettigheter til.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.20 (V): Et seksjonert dokument bør bare kunne åpnes av bruker som dokumenteier har gitt rettigheter til. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>15</showOrder>
-                            <requirementText>NOARK 7.3.24 (V): Leserettighetene til et dokument som er under arbeid,
-                                skal kunne avgrenses til roller og personer som gjennom parametersetting har generelle
-                                rettigheter til dette, eller de roller og personer som dokumenteier gir eksplisitte
-                                rettigheter.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.24 (V): Leserettighetene til et dokument som er under arbeid, skal kunne avgrenses til roller og personer som gjennom parametersetting har generelle rettigheter til dette, eller de roller og personer som dokumenteier gir eksplisitte rettigheter. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>16</showOrder>
-                            <requirementText>NOARK 7.3.25 (V): Det skal være parameterstyrte muligheter til å definere
-                                leserettighetene til alle dokumenter som er under arbeid.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.25 (V): Det skal være parameterstyrte muligheter til å definere leserettighetene til alle dokumenter som er under arbeid. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>17</showOrder>
-                            <requirementText>NOARK 7.3.26 (V): Det skal være parameterstyrte muligheter til å definere
-                                leserettighetene til ett eller flere bestemte dokument som er under arbeid, spesifikt
-                                for det enkelte dokumentet.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.26 (V): Det skal være parameterstyrte muligheter til å definere leserettighetene til ett eller flere bestemte dokument som er under arbeid, spesifikt for det enkelte dokumentet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>18</showOrder>
-                            <requirementText>NOARK 7.3.27 (V): Det skal være mulig for dokumenteier å overstyre
-                                parametersettingen.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.27 (V): Det skal være mulig for dokumenteier å overstyre parametersettingen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>19</showOrder>
-                            <requirementText>NOARK 7.3.28 (V): Når et egenprodusert dokument som er under arbeid sendes
-                                på arbeidsflyt, saksflyt eller dokumentflyt, skal alle mottakere av flyten automatisk
-                                autoriseres for lesetilgang til dokumentet uavhengig av rolle, administrativ enhet eller
-                                autorisasjon.
-                            </requirementText>
+                            <requirementText>NOARK 7.3.28 (V): Når et egenprodusert dokument som er under arbeid sendes på arbeidsflyt, saksflyt eller dokumentflyt, skal alle mottakere av flyten automatisk autoriseres for lesetilgang til dokumentet uavhengig av rolle, administrativ enhet eller autorisasjon. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
@@ -2073,158 +1404,112 @@
                 <section>
                     <sectionOrder>3</sectionOrder>
                     <sectionTitle>Krav til maler</sectionTitle>
-                    <description>Kravene sikrer at produksjon og forvaltning av maler foregår på en enkel og effektiv
-                        måte.
-                    </description>
-                    <explanation>Bruk av maler er vanlig i forvaltningen, og det er behov for at løsningen støtter en
-                        enkel og effektiv forvaltning av malene.
-                    </explanation>
-                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig i løsningen, kan det bli det bli mer
-                        manuelt arbeid når dokumenter produseres som en del av saksbehandlingen.
-                    </consequence>
+                    <description>Kravene sikrer at produksjon og forvaltning av maler foregår på en enkel og effektiv måte. </description>
+                    <explanation>Bruk av maler er vanlig i forvaltningen, og det er behov for at løsningen støtter en enkel og effektiv forvaltning av malene. </explanation>
+                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig i løsningen, kan det bli det bli mer manuelt arbeid når dokumenter produseres som en del av saksbehandlingen. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 7.4.1 (V): Det skal finnes funksjoner for å etablere dokumentmaler
-                                for alle dokumentkategorier som en virksomhet benytter.
-                            </requirementText>
+                            <requirementText>NOARK 7.4.1 (V): Det skal finnes funksjoner for å etablere dokumentmaler for alle dokumentkategorier som en virksomhet benytter. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 7.4.2 (V): Det skal finnes funksjoner for å utforme og bruke
-                                egendefinerte dokumentmaler.
-                            </requirementText>
+                            <requirementText>NOARK 7.4.2 (V): Det skal finnes funksjoner for å utforme og bruke egendefinerte dokumentmaler. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 7.4.3 (V): Det skal finnes funksjoner for å etablere nye
-                                dokumentmaler.
-                            </requirementText>
+                            <requirementText>NOARK 7.4.3 (V): Det skal finnes funksjoner for å etablere nye dokumentmaler. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 7.4.4 (V): Det skal finnes funksjoner for at virksomheten selv kan
-                                lage/utarbeide dokumentmaler uten ekstern bistand.
-                            </requirementText>
+                            <requirementText>NOARK 7.4.4 (V): Det skal finnes funksjoner for at virksomheten selv kan lage/utarbeide dokumentmaler uten ekstern bistand. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 7.4.5 (V): Det skal være mulig å legge inn to kategorier
-                                standardtekst i dokumentmalene, tekst som kan endres av saksbehandler og tekst som ikke
-                                kan endres av saksbehandler.
-                            </requirementText>
+                            <requirementText>NOARK 7.4.5 (V): Det skal være mulig å legge inn to kategorier standardtekst i dokumentmalene, tekst som kan endres av saksbehandler og tekst som ikke kan endres av saksbehandler. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 7.4.6 (V): Informasjon fra felt i Komplett Noark 5 skal kunne
-                                overføres automatisk til korresponderende felt i dokumentmalen.
-                            </requirementText>
+                            <requirementText>NOARK 7.4.6 (V): Informasjon fra felt i Komplett Noark 5 skal kunne overføres automatisk til korresponderende felt i dokumentmalen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 7.4.7 (V): Informasjon fra et felt i dokumentmalen skal kunne
-                                overføres automatisk til korresponderende felt i Komplett Noark 5.
-                            </requirementText>
+                            <requirementText>NOARK 7.4.7 (V): Informasjon fra et felt i dokumentmalen skal kunne overføres automatisk til korresponderende felt i Komplett Noark 5. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 7.4.8 (V): Ved skjerming av dokumenter, skal henvisning til hjemmel
-                                kunne skrives inn eller velges fritt av saksbehandler og løsningen plasserer teksten på
-                                angitt sted i dokumentmalen
-                            </requirementText>
+                            <requirementText>NOARK 7.4.8 (V): Ved skjerming av dokumenter, skal henvisning til hjemmel kunne skrives inn eller velges fritt av saksbehandler og løsningen plasserer teksten på angitt sted i dokumentmalen </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>Det skal være mulig å definere maler i minimum følgende dokumentformater;
-                                Word/tekstbehandler, Excel/regneark, Powerpoint/presentasjoner
-                            </requirementText>
+                            <requirementText>Det skal være mulig å definere maler i minimum følgende dokumentformater; Word/tekstbehandler, Excel/regneark, Powerpoint/presentasjoner </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>Dokumentmalene skal kunne tilrettelegges med felt som fletter inn
-                                informasjon fra alle felt i sak-/arkivløsningen.
-                            </requirementText>
+                            <requirementText>Dokumentmalene skal kunne tilrettelegges med felt som fletter inn informasjon fra alle felt i sak-/arkivløsningen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>Dersom flettefelter som ligger i malen ikke brukes i dokumentet som
-                                skrives, dvs. feltet er tomt, skal det ikke vises noe informasjon i dokumentet når det
-                                er ferdig produsert/flettet (feltkoder eller annet).
-                            </requirementText>
+                            <requirementText>Dersom flettefelter som ligger i malen ikke brukes i dokumentet som skrives, dvs. feltet er tomt, skal det ikke vises noe informasjon i dokumentet når det er ferdig produsert/flettet (feltkoder eller annet). </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>Det skal være mulig å flette opplysninger på nytt ved endringer etter
-                                første gangs lagring.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å flette opplysninger på nytt ved endringer etter første gangs lagring. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>13</showOrder>
-                            <requirementText>Den enkelte bruker skal til enhver tid kun ha tilgang til de malene som er
-                                relevante knyttet til egen rolle og til den sakstypen vedkommende arbeider med.
-                            </requirementText>
+                            <requirementText>Den enkelte bruker skal til enhver tid kun ha tilgang til de malene som er relevante knyttet til egen rolle og til den sakstypen vedkommende arbeider med. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>14</showOrder>
-                            <requirementText>Det skal være mulig å tilrettelegge malene slik at de stilene og den layout
-                                som er definert ikke kan endres av bruker (som ikke har tilgang til å administrere
-                                maler).
-                            </requirementText>
+                            <requirementText>Det skal være mulig å tilrettelegge malene slik at de stilene og den layout som er definert ikke kan endres av bruker (som ikke har tilgang til å administrere maler). </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>15</showOrder>
-                            <requirementText>Leverandøren skal som del av implementerings-prosjektet tilrettelegge
-                                standardmaler for brev, notat og møtebehandling. Disse skal danne grunnlag for at
-                                kommunen selv kan videreutvikle varianter av malene.
-                            </requirementText>
+                            <requirementText>Leverandøren skal som del av implementerings-prosjektet tilrettelegge standardmaler for brev, notat og møtebehandling. Disse skal danne grunnlag for at kommunen selv kan videreutvikle varianter av malene. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>16</showOrder>
-                            <requirementText>Leverandøren skal levere dokumentasjon / bruksanvisning som gir Kunden
-                                nøyaktig innføring i hvordan maler skal opprettes og videreutvikles. Dokumentasjonen
-                                skal være tilpasset den løsningen som leveres Kunden.
-                            </requirementText>
+                            <requirementText>Leverandøren skal levere dokumentasjon / bruksanvisning som gir Kunden nøyaktig innføring i hvordan maler skal opprettes og videreutvikles. Dokumentasjonen skal være tilpasset den løsningen som leveres Kunden. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>17</showOrder>
-                            <requirementText>Det skal være mulig å legge inn eksterne skjemaer/ blanketter slik at de
-                                kan benyttes på lik linje som maler.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å legge inn eksterne skjemaer/ blanketter slik at de kan benyttes på lik linje som maler. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -2233,80 +1518,57 @@
                     <sectionOrder>4</sectionOrder>
                     <sectionTitle>Krav til saks- og dokumenthistorikk</sectionTitle>
                     <description>Kravene sikrer muligheten for å holde god oversikt over saksgangen.</description>
-                    <explanation>For det daglige kvalitetssikringsarbeidet i arkivtjenesten, er denne funksjonaliteten
-                        viktig.
-                    </explanation>
-                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig i løsningen, kan det bli vanskeligere for
-                        arkivtjenesten å utføre kontroll over arkivering og saksbehandlingen.
-                    </consequence>
+                    <explanation>For det daglige kvalitetssikringsarbeidet i arkivtjenesten, er denne funksjonaliteten viktig. </explanation>
+                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig i løsningen, kan det bli vanskeligere for arkivtjenesten å utføre kontroll over arkivering og saksbehandlingen. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 7.5.1 (V): Det skal være mulig, på en enkel måte, å spore fakta for
-                                den enkelte sak, både uavsluttete og avsluttete.
-                            </requirementText>
+                            <requirementText>NOARK 7.5.1 (V): Det skal være mulig, på en enkel måte, å spore fakta for den enkelte sak, både uavsluttete og avsluttete. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 7.5.2 (V): Det skal være mulig å se hva som har vært gjort med saken,
-                                når det har skjedd og hvem som utførte handlingen (person eller løsning).
-                            </requirementText>
+                            <requirementText>NOARK 7.5.2 (V): Det skal være mulig å se hva som har vært gjort med saken, når det har skjedd og hvem som utførte handlingen (person eller løsning). </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 7.5.3 (V): Det skal være mulig å se nye saksmapper eller dokumenter
-                                som ikke er fordelt, påbegynt eller åpnet.
-                            </requirementText>
+                            <requirementText>NOARK 7.5.3 (V): Det skal være mulig å se nye saksmapper eller dokumenter som ikke er fordelt, påbegynt eller åpnet. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 7.5.4 (V): Det skal være mulig å se hva som er status for saksmappen
-                                eller dokumentet, dvs. om det har status ikke er fordelt, status ikke påbegynt eller
-                                status ikke åpnet.
-                            </requirementText>
+                            <requirementText>NOARK 7.5.4 (V): Det skal være mulig å se hva som er status for saksmappen eller dokumentet, dvs. om det har status ikke er fordelt, status ikke påbegynt eller status ikke åpnet. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 7.5.5 (V): Det skal være mulig å se at saksmapper og dokumenter
-                                ligger hos saksbehandler og venter på handling fra ham/henne.
-                            </requirementText>
+                            <requirementText>NOARK 7.5.5 (V): Det skal være mulig å se at saksmapper og dokumenter ligger hos saksbehandler og venter på handling fra ham/henne. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 7.5.6 (V): Det skal være mulig å se at saksmapper og dokumenter er
-                                sendt til godkjenning internt.
-                            </requirementText>
+                            <requirementText>NOARK 7.5.6 (V): Det skal være mulig å se at saksmapper og dokumenter er sendt til godkjenning internt. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 7.5.7 (V): Det skal være mulig å se at saksmapper eller dokumenter er
-                                til behandling hos et eksternt organ, f. eks. hos klageorgan, annet behandlende organ
-                                eller i rettsapparatet.
-                            </requirementText>
+                            <requirementText>NOARK 7.5.7 (V): Det skal være mulig å se at saksmapper eller dokumenter er til behandling hos et eksternt organ, f. eks. hos klageorgan, annet behandlende organ eller i rettsapparatet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 7.5.8 (V): Det skal være mulig å la alle dokumenter som inngår i
-                                saksmappen samt referanser til andre dokumenter (fra Internett, sakarkivet med mer) som
-                                inngår i et saksforhold, følge saksmappen.
-                            </requirementText>
+                            <requirementText>NOARK 7.5.8 (V): Det skal være mulig å la alle dokumenter som inngår i saksmappen samt referanser til andre dokumenter (fra Internett, sakarkivet med mer) som inngår i et saksforhold, følge saksmappen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -2314,124 +1576,88 @@
                 <section>
                     <sectionOrder>5</sectionOrder>
                     <sectionTitle>Krav til dokumentflyt</sectionTitle>
-                    <description>Kravene sikrer at dokumentflyten mellom de ulike leddene kan foregå på en effektiv måte
-                        internt i systemet.
-                    </description>
-                    <explanation>I saksbehandlingen vil det ofte være behov for at ulike aktører foretar ulike
-                        operasjoner knyttet til et dokument. Det er viktig for både kvalitet og effektivitet at
-                        løsningen legger til rette for god dokumentflyt.
-                    </explanation>
-                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig, eller ikke er god nok, vil det kunne
-                        oppstå hindringer og forsinkelser i dokumentflyten, noe som vil føre til lengre
-                        saksbehandlingstid og lavere effektivitet.
-                    </consequence>
+                    <description>Kravene sikrer at dokumentflyten mellom de ulike leddene kan foregå på en effektiv måte internt i systemet. </description>
+                    <explanation>I saksbehandlingen vil det ofte være behov for at ulike aktører foretar ulike operasjoner knyttet til et dokument. Det er viktig for både kvalitet og effektivitet at løsningen legger til rette for god dokumentflyt. </explanation>
+                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig, eller ikke er god nok, vil det kunne oppstå hindringer og forsinkelser i dokumentflyten, noe som vil føre til lengre saksbehandlingstid og lavere effektivitet. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 7.6.1 (V): Et dokument som er under produksjon, skal kunne sendes
-                                fram og tilbake i linjen det nødvendige antall ganger.
-                            </requirementText>
+                            <requirementText>NOARK 7.6.1 (V): Et dokument som er under produksjon, skal kunne sendes fram og tilbake i linjen det nødvendige antall ganger. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 7.6.2 (V): Autoriserte roller og personer skal kunne se hvor
-                                dokumentet befinner seg til enhver tid.
-                            </requirementText>
+                            <requirementText>NOARK 7.6.2 (V): Autoriserte roller og personer skal kunne se hvor dokumentet befinner seg til enhver tid. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 7.6.3 (V): Dokumentet skal bli sperret for endringer når det
-                                (videre)sendes, ev. det opprettes en ny versjon ved hver (videre)forsendelse.
-                            </requirementText>
+                            <requirementText>NOARK 7.6.3 (V): Dokumentet skal bli sperret for endringer når det (videre)sendes, ev. det opprettes en ny versjon ved hver (videre)forsendelse. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 7.6.4 (V): All funksjonalitet for korrektur og merknader i tilknyttet
-                                tekstbehandlingssystem skal kunne brukes på et dokument som er under produksjon.
-                            </requirementText>
+                            <requirementText>NOARK 7.6.4 (V): All funksjonalitet for korrektur og merknader i tilknyttet tekstbehandlingssystem skal kunne brukes på et dokument som er under produksjon. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 7.6.5 (V): Det skal være mulig å registrere merknader til
-                                dokumentet.
-                            </requirementText>
+                            <requirementText>NOARK 7.6.5 (V): Det skal være mulig å registrere merknader til dokumentet. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 7.6.6 (V): Mottaker av et dokument på flyt, skal bli varslet om at
-                                han/hun har mottatt et dokument.
-                            </requirementText>
+                            <requirementText>NOARK 7.6.6 (V): Mottaker av et dokument på flyt, skal bli varslet om at han/hun har mottatt et dokument. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 7.6.7 (V): Det skal være mulig å gi en forpliktende «signatur» i alle
-                                ledd.
-                            </requirementText>
+                            <requirementText>NOARK 7.6.7 (V): Det skal være mulig å gi en forpliktende «signatur» i alle ledd. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 7.6.8 (V): Det skal være mulig å la vedlegg til hoveddokumentet og
-                                referanser til andre vedlegg (fra Internett, sakarkivet med mer) følge dokumentet
-                            </requirementText>
+                            <requirementText>NOARK 7.6.8 (V): Det skal være mulig å la vedlegg til hoveddokumentet og referanser til andre vedlegg (fra Internett, sakarkivet med mer) følge dokumentet </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>NOARK 7.6.9 (V): Det skal være mulig å sende et dokument som er under
-                                produksjon, til trinnvis godkjenning (sekvensielt)
-                            </requirementText>
+                            <requirementText>NOARK 7.6.9 (V): Det skal være mulig å sende et dokument som er under produksjon, til trinnvis godkjenning (sekvensielt) </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>NOARK 7.6.10 (V): Det skal være mulig å sende et dokument som er under
-                                produksjon, til høring til flere samtidig (parallelt)
-                            </requirementText>
+                            <requirementText>NOARK 7.6.10 (V): Det skal være mulig å sende et dokument som er under produksjon, til høring til flere samtidig (parallelt) </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>NOARK 7.6.11 (V): For dokument som er under produksjon, og som sendes på
-                                sekvensiell eller parallell dokumentflyt, skal det kunne parameterstyres om det
-                                automatisk skal opprettes nye versjoner for alle mottakere i flyten.
-                            </requirementText>
+                            <requirementText>NOARK 7.6.11 (V): For dokument som er under produksjon, og som sendes på sekvensiell eller parallell dokumentflyt, skal det kunne parameterstyres om det automatisk skal opprettes nye versjoner for alle mottakere i flyten. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>NOARK 7.6.12 (V): Det skal kunne parameterstyres om versjonering skal
-                                forekomme bare for enkelte roller, enheter, grupper eller personer. Dette skal kunne
-                                gjøres fast eller på ad-hoc-basis.
-                            </requirementText>
+                            <requirementText>NOARK 7.6.12 (V): Det skal kunne parameterstyres om versjonering skal forekomme bare for enkelte roller, enheter, grupper eller personer. Dette skal kunne gjøres fast eller på ad-hoc-basis. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>13</showOrder>
-                            <requirementText>Det skal være enkelt for brukeren etter behov å gi saksbehandlere og ledere
-                                i kommunen tilgang til å arbeide med dokumenter i fellesskap.
-                            </requirementText>
+                            <requirementText>Det skal være enkelt for brukeren etter behov å gi saksbehandlere og ledere i kommunen tilgang til å arbeide med dokumenter i fellesskap. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -2439,166 +1665,112 @@
                 <section>
                     <sectionOrder>6</sectionOrder>
                     <sectionTitle>Krav til arbeidsflyt</sectionTitle>
-                    <description>Kravene sikrere at det er mulig å fordele arbeidsoppgaver og følge opp og holde
-                        oversikt over oppgavene.
-                    </description>
-                    <explanation>Arbeidsflyt vil ofte basere seg på styring av kommunikasjonen mellom ulike personer og
-                        roller og informasjonssystemer er en del av en arbeidsprosess. Det er en viktig del av
-                        saksbehandlingsprosessen.
-                    </explanation>
-                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig, eller ikke er god nok, vil det kunne
-                        oppstå hindringer og forsinkelser, noe som vil føre til lengre saksbehandlingstid og lavere
-                        effektivitet.
-                    </consequence>
+                    <description>Kravene sikrere at det er mulig å fordele arbeidsoppgaver og følge opp og holde oversikt over oppgavene. </description>
+                    <explanation>Arbeidsflyt vil ofte basere seg på styring av kommunikasjonen mellom ulike personer og roller og informasjonssystemer er en del av en arbeidsprosess. Det er en viktig del av saksbehandlingsprosessen. </explanation>
+                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig, eller ikke er god nok, vil det kunne oppstå hindringer og forsinkelser, noe som vil føre til lengre saksbehandlingstid og lavere effektivitet. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 7.7.1 (V): Det skal være mulig å ekspedere (sende) en oppgave, en sak
-                                eller et dokument som er ferdig fra saksbehandler på arbeidsflyt internt.
-                            </requirementText>
+                            <requirementText>NOARK 7.7.1 (V): Det skal være mulig å ekspedere (sende) en oppgave, en sak eller et dokument som er ferdig fra saksbehandler på arbeidsflyt internt. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 7.7.2 (V): Det skal være mulig å legge opp en arbeidsflyt (både
-                                forhåndsdefinert og ad-hoc) med forhåndsdefinerte aktiviteter og milepæler.
-                            </requirementText>
+                            <requirementText>NOARK 7.7.2 (V): Det skal være mulig å legge opp en arbeidsflyt (både forhåndsdefinert og ad-hoc) med forhåndsdefinerte aktiviteter og milepæler. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 7.7.3 (V): Det skal være mulig å forhåndsdefinere både sekvensiell
-                                arbeidsflyt og samtidig arbeidsflyt
-                            </requirementText>
+                            <requirementText>NOARK 7.7.3 (V): Det skal være mulig å forhåndsdefinere både sekvensiell arbeidsflyt og samtidig arbeidsflyt </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 7.7.4 (V): Det skal være mulig å legge inn kontrollfunksjonalitet for
-                                de enkelte aktiviteter, f. eks. at arbeidsoppgaven eller saken ikke går videre i flyten
-                                før alle aktiviteter er utført.
-                            </requirementText>
+                            <requirementText>NOARK 7.7.4 (V): Det skal være mulig å legge inn kontrollfunksjonalitet for de enkelte aktiviteter, f. eks. at arbeidsoppgaven eller saken ikke går videre i flyten før alle aktiviteter er utført. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 7.7.5 (V): Det skal være mulig å legge inn tidsbestemte aktiviteter,
-                                for eksempel hvis en sak ikke er åpnet på et angitt antall dager så skal den automatisk
-                                sendes videre i løsningen til en alias e.l.
-                            </requirementText>
+                            <requirementText>NOARK 7.7.5 (V): Det skal være mulig å legge inn tidsbestemte aktiviteter, for eksempel hvis en sak ikke er åpnet på et angitt antall dager så skal den automatisk sendes videre i løsningen til en alias e.l. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 7.7.7 (V): Det skal være mulig å ekspedere (sende) en oppgave, en sak
-                                eller et dokument som er ferdig fra saksbehandler, på trinnvis arbeidsflyt internt, dvs
-                                at det automatisk sendes videre til neste trinn når det foregående er ferdig med
-                                oppgaven.
-                            </requirementText>
+                            <requirementText>NOARK 7.7.7 (V): Det skal være mulig å ekspedere (sende) en oppgave, en sak eller et dokument som er ferdig fra saksbehandler, på trinnvis arbeidsflyt internt, dvs at det automatisk sendes videre til neste trinn når det foregående er ferdig med oppgaven. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 7.7.8 (V): Det skal være mulig for alle mottakere i den trinnvise,
-                                interne arbeidsflyten å knytte en merknad eller et dokument til den opprinnelige
-                                oppgaven, saken eller dokumentet.
-                            </requirementText>
+                            <requirementText>NOARK 7.7.8 (V): Det skal være mulig for alle mottakere i den trinnvise, interne arbeidsflyten å knytte en merknad eller et dokument til den opprinnelige oppgaven, saken eller dokumentet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 7.7.9 (V): Når et dokument som er ferdig fra saksbehandler sendes på
-                                arbeidsflyt internt, skal dokumentet som er i arbeidsflyten ikke kunne endres eller
-                                slettes.
-                            </requirementText>
+                            <requirementText>NOARK 7.7.9 (V): Når et dokument som er ferdig fra saksbehandler sendes på arbeidsflyt internt, skal dokumentet som er i arbeidsflyten ikke kunne endres eller slettes. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>NOARK 7.7.10 (V): Det skal være mulig å overstyre den forhåndsdefinerte
-                                arbeidsflyten av autorisert personale.
-                            </requirementText>
+                            <requirementText>NOARK 7.7.10 (V): Det skal være mulig å overstyre den forhåndsdefinerte arbeidsflyten av autorisert personale. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>NOARK 7.7.11(V): Det skal være mulig å gi en forpliktende «signatur» i alle
-                                ledd.
-                            </requirementText>
+                            <requirementText>NOARK 7.7.11(V): Det skal være mulig å gi en forpliktende «signatur» i alle ledd. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>NOARK 7.7.12 (V): Sporingselementer fra en arbeidsflyt skal logges og
-                                bevares. Sporingselementene er: Hvem har mottatt oppgaven/saken/dokumentet, Hvem har
-                                lest eller redigert oppgaven / saken / dokumentet, Hvordan har den enkelte mottaker
-                                håndtert oppgaven/saken/dokumentet (f. eks. godkjent/ikke godkjent),Hva har vedkommende
-                                gjort (f. eks. lest/ redigert/videresendt) Ev. forpliktende «signatur», Kommentarer som
-                                er lagt inn i arbeidsflyten/oppgaven/saken/dokumentet
-                            </requirementText>
+                            <requirementText>NOARK 7.7.12 (V): Sporingselementer fra en arbeidsflyt skal logges og bevares. Sporingselementene er: Hvem har mottatt oppgaven/saken/dokumentet, Hvem har lest eller redigert oppgaven / saken / dokumentet, Hvordan har den enkelte mottaker håndtert oppgaven/saken/dokumentet (f. eks. godkjent/ikke godkjent),Hva har vedkommende gjort (f. eks. lest/ redigert/videresendt) Ev. forpliktende «signatur», Kommentarer som er lagt inn i arbeidsflyten/oppgaven/saken/dokumentet </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>NOARK 7.7.13 (V): Det skal finnes en funksjon for å søke fram eksterne og
-                                interne dokumenter med behandlingsfrist i et angitt tidsrom.
-                            </requirementText>
+                            <requirementText>NOARK 7.7.13 (V): Det skal finnes en funksjon for å søke fram eksterne og interne dokumenter med behandlingsfrist i et angitt tidsrom. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>13</showOrder>
-                            <requirementText>NOARK 7.7.14 (V): Søket skal kunne begrenses med utgangspunkt i
-                                saksbehandlende enhet og saksbehandler.
-                            </requirementText>
+                            <requirementText>NOARK 7.7.14 (V): Søket skal kunne begrenses med utgangspunkt i saksbehandlende enhet og saksbehandler. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>14</showOrder>
-                            <requirementText>NOARK 7.7.15 (V): Det skal finnes en funksjon for automatisert varsling av
-                                interne eller eksterne tidsfrister som er i ferd med å bli overskredet.
-                            </requirementText>
+                            <requirementText>NOARK 7.7.15 (V): Det skal finnes en funksjon for automatisert varsling av interne eller eksterne tidsfrister som er i ferd med å bli overskredet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>15</showOrder>
-                            <requirementText>Det skal være mulig å konfigurere/sette opp saks- og dokumentflyt i
-                                løsningen. Det skal være mulig å sette en saks- og dokumentflyt som «låser» de stegene
-                                og funksjonene som er tilgjengelige.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å konfigurere/sette opp saks- og dokumentflyt i løsningen. Det skal være mulig å sette en saks- og dokumentflyt som «låser» de stegene og funksjonene som er tilgjengelige. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>16</showOrder>
-                            <requirementText>Det skal være mulig å angi verdi (antall virkedager) for forventet
-                                saksbehandlingstid per sakstype, slik at det ved sakens opprettelse tilordnes en dato
-                                for «forfall» / «forventet ferdigbehandlet» eller ny aktivitet.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å angi verdi (antall virkedager) for forventet saksbehandlingstid per sakstype, slik at det ved sakens opprettelse tilordnes en dato for «forfall» / «forventet ferdigbehandlet» eller ny aktivitet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>17</showOrder>
-                            <requirementText>Saker som ikke er ferdigbehandlet innen angitt«forfallsdato» skal markeres
-                                på en tydelig måte
-                            </requirementText>
+                            <requirementText>Saker som ikke er ferdigbehandlet innen angitt«forfallsdato» skal markeres på en tydelig måte </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -2606,13 +1778,8 @@
                 <section>
                     <sectionOrder>7</sectionOrder>
                     <sectionTitle>Øvrige krav til saksbehandlerfunksjonalitet</sectionTitle>
-                    <description>I dette kapittelet er listet opp noen forslag til krav til saksbehandlingsunksjonalitet
-                        som ansees å være relevante og som ikke er en del av Noark standarden.
-                    </description>
-                    <explanation>Kravene i kapittelet bør gjennomgås med tanke på relevans for organisasjonen. Det vil
-                        også være naturlig å benytte dette kapittelet for å stille andre egendefinerte krav til
-                        saksbehandlingsfunksjonalitet.
-                    </explanation>
+                    <description>I dette kapittelet er listet opp noen forslag til krav til saksbehandlingsunksjonalitet som ansees å være relevante og som ikke er en del av Noark standarden. </description>
+                    <explanation>Kravene i kapittelet bør gjennomgås med tanke på relevans for organisasjonen. Det vil også være naturlig å benytte dette kapittelet for å stille andre egendefinerte krav til saksbehandlingsfunksjonalitet. </explanation>
                     <consequence></consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
@@ -2620,111 +1787,79 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 10.2.1 (V): Det skal være mulig å sette opp varslinger (f. eks. i
-                                form av meldingsbokser) når tidsfrister er overskredet m.v.
-                            </requirementText>
+                            <requirementText>NOARK 10.2.1 (V): Det skal være mulig å sette opp varslinger (f. eks. i form av meldingsbokser) når tidsfrister er overskredet m.v. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>Løsningen skal kunne håndtere all saksbehandling elektronisk slik at man
-                                ikke blir tvunget til å opprettholde papirarkiv pga. begrensninger i løsningen.
-                                Eventuelle begrensninger og forutsetninger knyttet til dette skal beskrives.
-                            </requirementText>
+                            <requirementText>Løsningen skal kunne håndtere all saksbehandling elektronisk slik at man ikke blir tvunget til å opprettholde papirarkiv pga. begrensninger i løsningen. Eventuelle begrensninger og forutsetninger knyttet til dette skal beskrives. </requirementText>
                             <priority>1 (i)</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>Løsningen skal muliggjøre sikker og effektiv journalføring av sms/chat.
-                                Løsningen må også håndtere innkommende svar på sendte sms/chat. Leverandøren skal
-                                beskrive hvordan løsningen håndterer dette – ved utsendelse av sms/chat fra selve
-                                løsningen, alternativt også mulighet for journalføring av sms til og fra mobiltelefon.
-                            </requirementText>
+                            <requirementText>Løsningen skal muliggjøre sikker og effektiv journalføring av sms/chat. Løsningen må også håndtere innkommende svar på sendte sms/chat. Leverandøren skal beskrive hvordan løsningen håndterer dette – ved utsendelse av sms/chat fra selve løsningen, alternativt også mulighet for journalføring av sms til og fra mobiltelefon. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>Leverandøren skal beskrive hvordan tilbudt løsning tilrettelegger for
-                                forenklet registrering jf. NOARK5, og hvilke utfordringer bruk av forenklet registrering
-                                kan medføre for den enkelte bruker, og for kommunen.
-                            </requirementText>
+                            <requirementText>Leverandøren skal beskrive hvordan tilbudt løsning tilrettelegger for forenklet registrering jf. NOARK5, og hvilke utfordringer bruk av forenklet registrering kan medføre for den enkelte bruker, og for kommunen. </requirementText>
                             <priority>O (i)</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>Mottaker av notater skal enkelt kunne avskrive disse, dvs. det skal ikke
-                                være behov for mer enn én operasjon for å registrere et notat som mottatt og avskrevet.
-                            </requirementText>
+                            <requirementText>Mottaker av notater skal enkelt kunne avskrive disse, dvs. det skal ikke være behov for mer enn én operasjon for å registrere et notat som mottatt og avskrevet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>Det skal være lett å få oversikt over egne restanser –
-                                henvendelser/dokumenter
-                            </requirementText>
+                            <requirementText>Det skal være lett å få oversikt over egne restanser – henvendelser/dokumenter </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>Det skal være mulig å flette svarbrev til mange på en enkel måte, dvs. å
-                                produsere likelydende brev til mange mottakere.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å flette svarbrev til mange på en enkel måte, dvs. å produsere likelydende brev til mange mottakere. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>Saksbehandler skal kunne legge på flere mottakere på en inngående
-                                journalpost og ekspedere dokumenter og vedlegg selv (dvs. videresende dette som en ny
-                                utgående post). Ekspedering må skje med godkjente arkivformat.
-                            </requirementText>
+                            <requirementText>Saksbehandler skal kunne legge på flere mottakere på en inngående journalpost og ekspedere dokumenter og vedlegg selv (dvs. videresende dette som en ny utgående post). Ekspedering må skje med godkjente arkivformat. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>Det skal være enkelt å knytte til vedlegg som skal være med til en
-                                journalpost.
-                            </requirementText>
+                            <requirementText>Det skal være enkelt å knytte til vedlegg som skal være med til en journalpost. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>Et hoveddokument må kunne være vedlegg på en annen journalpost.
-                            </requirementText>
+                            <requirementText>Et hoveddokument må kunne være vedlegg på en annen journalpost. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>Leder skal kunne flytte arkivsaker mellom de ulike saksbehandlerne innenfor
-                                egen organisasjonsenhet. Endringer skal logges.
-                            </requirementText>
+                            <requirementText>Leder skal kunne flytte arkivsaker mellom de ulike saksbehandlerne innenfor egen organisasjonsenhet. Endringer skal logges. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>Dersom det gjøres endringer i systemets registre for faste data/kodeverk
-                                skal historikk for disse registrene beholdes. Historikk skal imidlertid ikke være
-                                tilgjengelig for brukerne i det daglige. Eks. skal ikke utgåtte arkivnøkler være
-                                tilgjengelige for bruk/synlige.
-                            </requirementText>
+                            <requirementText>Dersom det gjøres endringer i systemets registre for faste data/kodeverk skal historikk for disse registrene beholdes. Historikk skal imidlertid ikke være tilgjengelig for brukerne i det daglige. Eks. skal ikke utgåtte arkivnøkler være tilgjengelige for bruk/synlige. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>13</showOrder>
-                            <requirementText>Det skal være mulig å laste inn dokumenter publisert på internett (også
-                                eksterne sider) på en enkel måte.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å laste inn dokumenter publisert på internett (også eksterne sider) på en enkel måte. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -2738,74 +1873,51 @@
                 <section>
                     <sectionOrder>1</sectionOrder>
                     <sectionTitle>Overordnede krav til e-postfunksjonalitet</sectionTitle>
-                    <description>Kravene sikrer at all kommunikasjon mottatt og sendt via e-post blir journalført, samt
-                        effektivisere hverdagen ved å tilrettelegge for utstrakt bruk av e-post i saksbehandlingen.
-                    </description>
-                    <explanation>E-post brukes etterhvert svært mye i saksbehandling. Det betyr at mange dokumenter
-                        ekspederes og mottas via denne kanalen. En enkel behandling av e.-post vil derfor sikre at
-                        kommunikasjonen bevares.
-                    </explanation>
-                    <consequence>Dersom ikke krav til e-post oppfylles vil håndtering av denne kommunikasjonen i ulik
-                        grad kunne bli langt mer arbeidskrevende for organisasjonen. Dette vil også medføre en økt
-                        risiko for redusert dokumentfangst.
-                    </consequence>
+                    <description>Kravene sikrer at all kommunikasjon mottatt og sendt via e-post blir journalført, samt effektivisere hverdagen ved å tilrettelegge for utstrakt bruk av e-post i saksbehandlingen. </description>
+                    <explanation>E-post brukes etterhvert svært mye i saksbehandling. Det betyr at mange dokumenter ekspederes og mottas via denne kanalen. En enkel behandling av e.-post vil derfor sikre at kommunikasjonen bevares. </explanation>
+                    <consequence>Dersom ikke krav til e-post oppfylles vil håndtering av denne kommunikasjonen i ulik grad kunne bli langt mer arbeidskrevende for organisasjonen. Dette vil også medføre en økt risiko for redusert dokumentfangst. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>0</showOrder>
-                            <requirementText>Sikre at all kommunikasjon mottatt og sendt via e-post blir journalført,
-                                samt effektivisere hverdagen ved å tilrettelegge for utstrakt bruk av e-post i
-                                saksbehandlingen.
-                            </requirementText>
+                            <requirementText>Sikre at all kommunikasjon mottatt og sendt via e-post blir journalført, samt effektivisere hverdagen ved å tilrettelegge for utstrakt bruk av e-post i saksbehandlingen. </requirementText>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>Det skal være full integrasjon med kommunens e-postsystem.
-                            </requirementText>
+                            <requirementText>Det skal være full integrasjon med kommunens e-postsystem. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 8.1.2 (V): I løsningen skal det være mulig å ekspedere e-post som
-                                saksdokument.
-                            </requirementText>
+                            <requirementText>NOARK 8.1.2 (V): I løsningen skal det være mulig å ekspedere e-post som saksdokument. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 8.1.3 (V): I løsningen skal det være mulig å ekspedere saksdokumenter
-                                som e-post direkte fra aktuelle moduler.
-                            </requirementText>
+                            <requirementText>NOARK 8.1.3 (V): I løsningen skal det være mulig å ekspedere saksdokumenter som e-post direkte fra aktuelle moduler. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 8.1.4 (V): Innkommende e-post (med og uten vedlegg) skal kunne
-                                registreres direkte fra organets valgte e-postløsning.
-                            </requirementText>
+                            <requirementText>NOARK 8.1.4 (V): Innkommende e-post (med og uten vedlegg) skal kunne registreres direkte fra organets valgte e-postløsning. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 8.1.5 (V): I løsningen skal det være mulig å sende saksdokumenter
-                                (som kopi) som vedlegg til e-post direkte fra aktuelle moduler.
-                            </requirementText>
+                            <requirementText>NOARK 8.1.5 (V): I løsningen skal det være mulig å sende saksdokumenter (som kopi) som vedlegg til e-post direkte fra aktuelle moduler. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 8.1.6 (V): Det skal finnes en tjeneste / funksjon for at selve
-                                meldingsteksten i en egenprodusert e-post skal kunne sendes på dokumentflytinternt i
-                                organet før ekspedering, på samme måten som et vanlig tekstdokument.
-                            </requirementText>
+                            <requirementText>NOARK 8.1.6 (V): Det skal finnes en tjeneste / funksjon for at selve meldingsteksten i en egenprodusert e-post skal kunne sendes på dokumentflytinternt i organet før ekspedering, på samme måten som et vanlig tekstdokument. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -2814,47 +1926,27 @@
                     <sectionOrder>2</sectionOrder>
                     <sectionTitle>Krav til dokumentfangst, e-posthode og e-postmelding</sectionTitle>
                     <description>Kravene sikrer en effektiv metadata- og dokumentfangst av eposter.</description>
-                    <explanation>En stadig økende mengde kommunikasjon i - og med forvaltningen foregår på e-post. Store
-                        deler av denne kommunikasjonen vil være arkivverdig, og det er viktig at løsningen har gode og
-                        automatiserte løsninger for å fange arkivverdige opplysninger i form av dokumenter og metadata.
-                    </explanation>
-                    <consequence>Dersom ikke krav til metadata- og dokumentfagst av epost oppfylles vil håndtering av
-                        denne kommunikasjonen i ulik grad kunne bli langt mer arbeidskrevende for organisasjonen.
-                    </consequence>
+                    <explanation>En stadig økende mengde kommunikasjon i - og med forvaltningen foregår på e-post. Store deler av denne kommunikasjonen vil være arkivverdig, og det er viktig at løsningen har gode og automatiserte løsninger for å fange arkivverdige opplysninger i form av dokumenter og metadata. </explanation>
+                    <consequence>Dersom ikke krav til metadata- og dokumentfagst av epost oppfylles vil håndtering av denne kommunikasjonen i ulik grad kunne bli langt mer arbeidskrevende for organisasjonen. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 8.1.7 (V): Det skal finnes en tjeneste / funksjon som gjør det mulig
-                                automatisk å journalføre og arkivere dokumenter mottatt via e-post.
-                            </requirementText>
+                            <requirementText>NOARK 8.1.7 (V): Det skal finnes en tjeneste / funksjon som gjør det mulig automatisk å journalføre og arkivere dokumenter mottatt via e-post. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 8.1.12 (V): Det skal være mulig å parameterstyre løsningen ved
-                                ekspedering av e-post som saksdokument eller ekspedering av saksdokument per e-post slik
-                                at NOARK5-løsningen: 1)Automatisk journalfører og arkiverer e-posten med eventuelle
-                                vedlegg, 2) Automatisk håndterer e-posten med eventuelle vedlegg i tråd med
-                                forhåndsdefinerte regler i løsningen, 3) Automatisk gir melding til bruker med spørsmål
-                                om e-posten med eventuelle vedlegg skal journalføres og arkiveres 4) Baseres på manuelle
-                                rutiner
-                            </requirementText>
+                            <requirementText>NOARK 8.1.12 (V): Det skal være mulig å parameterstyre løsningen ved ekspedering av e-post som saksdokument eller ekspedering av saksdokument per e-post slik at NOARK5-løsningen: 1)Automatisk journalfører og arkiverer e-posten med eventuelle vedlegg, 2) Automatisk håndterer e-posten med eventuelle vedlegg i tråd med forhåndsdefinerte regler i løsningen, 3) Automatisk gir melding til bruker med spørsmål om e-posten med eventuelle vedlegg skal journalføres og arkiveres 4) Baseres på manuelle rutiner </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 8.1.13 (V): Det skal være mulig å parameterstyre NOARK5-løsningen ved
-                                mottak av e-post med eventuelle vedlegg slik at NOARK5-løsningen: 1) Automatisk
-                                journalfører og arkiverer (og eventuelt også fordeler) e-posten, 2) Automatisk håndterer
-                                e-posten med eventuelle vedlegg i tråd med forhåndsdefinerte regler i løsningen, 3)
-                                Automatisk gir melding til bruker med spørsmål om e-posten med eventuelle vedlegg skal
-                                journalføres og arkiveres, 3) Baseres på manuelle rutiner
-                            </requirementText>
+                            <requirementText>NOARK 8.1.13 (V): Det skal være mulig å parameterstyre NOARK5-løsningen ved mottak av e-post med eventuelle vedlegg slik at NOARK5-løsningen: 1) Automatisk journalfører og arkiverer (og eventuelt også fordeler) e-posten, 2) Automatisk håndterer e-posten med eventuelle vedlegg i tråd med forhåndsdefinerte regler i løsningen, 3) Automatisk gir melding til bruker med spørsmål om e-posten med eventuelle vedlegg skal journalføres og arkiveres, 3) Baseres på manuelle rutiner </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -2862,228 +1954,160 @@
                 <section>
                     <sectionOrder>3</sectionOrder>
                     <sectionTitle>Ekspedering av dokumenter med epost / som e-post</sectionTitle>
-                    <description>Kravene sikrer forventet funksjonalitet når saksdokumentet skal ekspederes som epost
-                        med eventuelle vedlegg.
-                    </description>
-                    <explanation>For å kunne realisere enkelte gevinster knyttet til elektronisk arkiv og bruk av
-                        noark-system, vil det være ønskelig/nødvendig å kunne ekspedere utgående dokumenter pr e-post.
-                    </explanation>
-                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig, eller ikke er god nok, vil det kunne
-                        skade brukernes lojalitet til systemet, som kan også føre til etablering av skyggearkiv i
-                        epostløsninger.
-                    </consequence>
+                    <description>Kravene sikrer forventet funksjonalitet når saksdokumentet skal ekspederes som epost med eventuelle vedlegg. </description>
+                    <explanation>For å kunne realisere enkelte gevinster knyttet til elektronisk arkiv og bruk av noark-system, vil det være ønskelig/nødvendig å kunne ekspedere utgående dokumenter pr e-post. </explanation>
+                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig, eller ikke er god nok, vil det kunne skade brukernes lojalitet til systemet, som kan også føre til etablering av skyggearkiv i epostløsninger. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 8.2.1 (V): Det skal finnes en tjeneste / funksjon for å ekspedere en
-                                e-post med eventuelle vedlegg som organets saksdokument, direkte fra Noark 5-løsningen.
-                            </requirementText>
+                            <requirementText>NOARK 8.2.1 (V): Det skal finnes en tjeneste / funksjon for å ekspedere en e-post med eventuelle vedlegg som organets saksdokument, direkte fra Noark 5-løsningen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 8.2.3 (V): Det skal finnes en tjeneste / funksjon for å ekspedere
-                                e-post som saksdokument ved bruk av utvekslingsformat.
-                            </requirementText>
+                            <requirementText>NOARK 8.2.3 (V): Det skal finnes en tjeneste / funksjon for å ekspedere e-post som saksdokument ved bruk av utvekslingsformat. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 8.3.1 (V): Det skal finnes en tjeneste/funksjon for å ekspedere
-                                saksdokumenter via e-post fra Noark 5-løsningen.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.1 (V): Det skal finnes en tjeneste/funksjon for å ekspedere saksdokumenter via e-post fra Noark 5-løsningen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 8.3.2 (V): Ved ekspedering av saksdokumenter per e-post skal
-                                løsningen fylle ut e-postens emnefelt med innholdsbeskrivelsen fra Registrering.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.2 (V): Ved ekspedering av saksdokumenter per e-post skal løsningen fylle ut e-postens emnefelt med innholdsbeskrivelsen fra Registrering. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 8.3.6 (V): Ved ekspedering av dokumenter per e-post skal løsningen
-                                sette organets sentrale epost-adresse som forslag til avsender.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.6 (V): Ved ekspedering av dokumenter per e-post skal løsningen sette organets sentrale epost-adresse som forslag til avsender. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 8.3.7 (V): Det skal være mulig å overstyre Noark 5-løsningen, til en
-                                annen e-postadresse som autentisert saksbehandler har tilgang og rettigheter til.
-                                Merknad: Dette kan eksempelvis være saksbehandlende avdelings e-postadresse eller
-                                saksbehandlers epost-adresse
-                            </requirementText>
+                            <requirementText>NOARK 8.3.7 (V): Det skal være mulig å overstyre Noark 5-løsningen, til en annen e-postadresse som autentisert saksbehandler har tilgang og rettigheter til. Merknad: Dette kan eksempelvis være saksbehandlende avdelings e-postadresse eller saksbehandlers epost-adresse </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 8.3.8 (V): Overstyring av «avsenders epost-adresse» skal kunne gjøres
-                                også på permanent basis.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.8 (V): Overstyring av «avsenders epost-adresse» skal kunne gjøres også på permanent basis. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 8.3.9 (V): Ved ekspedering av saksdokumenter via e-post skal
-                                løsningen sette opp alle «predefinerte mottakere» (mottakerliste) som er knyttet til
-                                aktuelle Registrering som forslag til e-post mottaker.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.9 (V): Ved ekspedering av saksdokumenter via e-post skal løsningen sette opp alle «predefinerte mottakere» (mottakerliste) som er knyttet til aktuelle Registrering som forslag til e-post mottaker. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>NOARK 8.3.10 (V): Muligheten for å endre e-postens mottakerliste skal være
-                                tilgjengelig som en funksjon under ekspedering av e-post.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.10 (V): Muligheten for å endre e-postens mottakerliste skal være tilgjengelig som en funksjon under ekspedering av e-post. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>NOARK 8.3.11 (V): Hvis e-postadressene ved en ekspedering endres i forhold
-                                til standard mottakerliste skal det lagres informasjon om dette.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.11 (V): Hvis e-postadressene ved en ekspedering endres i forhold til standard mottakerliste skal det lagres informasjon om dette. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>NOARK 8.3.12 (V): Det skal være mulig å manuelt overstyre predefinert
-                                e-postadresse i mottakerfeltet ved ekspedering.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.12 (V): Det skal være mulig å manuelt overstyre predefinert e-postadresse i mottakerfeltet ved ekspedering. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>NOARK 8.3.13 (V): Ved ekspedering av dokumenter per e-post skal det finnes
-                                en tjeneste/funksjon for å angi hvilke dokumenter som skal utgå fra ekspederingen.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.13 (V): Ved ekspedering av dokumenter per e-post skal det finnes en tjeneste/funksjon for å angi hvilke dokumenter som skal utgå fra ekspederingen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>13</showOrder>
-                            <requirementText>NOARK 8.3.14 (V): Det skal finnes en tjeneste / funksjon for å registrere
-                                merknader til de saksdokumenter som ikke medfølger en ekspedering.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.14 (V): Det skal finnes en tjeneste / funksjon for å registrere merknader til de saksdokumenter som ikke medfølger en ekspedering. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>14</showOrder>
-                            <requirementText>NOARK 8.3.15 (V): Ved ekspedering skal løsningen generere meldingstekst som
-                                gir kort informasjon om de saksdokumenter som eventuelt ikke medfølger
-                                e-postforsendelsen.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.15 (V): Ved ekspedering skal løsningen generere meldingstekst som gir kort informasjon om de saksdokumenter som eventuelt ikke medfølger e-postforsendelsen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>15</showOrder>
-                            <requirementText>NOARK 8.3.16 (V): For de saksdokumenter som ikke medfølger ekspedering skal
-                                systemgenerert meldingstekst samt eventuelle merknader registrert av saksbehandler
-                                alltid medfølge e-postekspederingen.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.16 (V): For de saksdokumenter som ikke medfølger ekspedering skal systemgenerert meldingstekst samt eventuelle merknader registrert av saksbehandler alltid medfølge e-postekspederingen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>16</showOrder>
-                            <requirementText>NOARK 8.3.18 (V): Ved ekspedering skal det utføres kontroll mot
-                                utvekslingsformatet.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.18 (V): Ved ekspedering skal det utføres kontroll mot utvekslingsformatet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>17</showOrder>
-                            <requirementText>NOARK 8.3.20 (V): Avbrutt ekspedering skal likevel kunne sendes når den
-                                godkjennes av saksbehandler med autorisasjon til å utføre den prosessen.
-                            </requirementText>
+                            <requirementText>NOARK 8.3.20 (V): Avbrutt ekspedering skal likevel kunne sendes når den godkjennes av saksbehandler med autorisasjon til å utføre den prosessen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>18</showOrder>
-                            <requirementText>Ekspedering av dokumenter skal kunne gjøres direkte fra bildet der
-                                saksbehandler jobber med saken (saksbildet).
-                            </requirementText>
+                            <requirementText>Ekspedering av dokumenter skal kunne gjøres direkte fra bildet der saksbehandler jobber med saken (saksbildet). </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>19</showOrder>
-                            <requirementText>Dersom dokumentet som skal ekspederes ikke er konvertert til arkivformat,
-                                skal konvertering automatisk skje ved ekspedering slik at mottaker får dokumentet i
-                                arkivformat.
-                            </requirementText>
+                            <requirementText>Dersom dokumentet som skal ekspederes ikke er konvertert til arkivformat, skal konvertering automatisk skje ved ekspedering slik at mottaker får dokumentet i arkivformat. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>20</showOrder>
-                            <requirementText>Ved gradering av vedlegg til en journalpost skal det være mulig å ekspedere
-                                hoveddokument og offentlige vedlegg uten manuell behandling. Systemet skal kun ekspedere
-                                offentlige dokumenter.
-                            </requirementText>
+                            <requirementText>Ved gradering av vedlegg til en journalpost skal det være mulig å ekspedere hoveddokument og offentlige vedlegg uten manuell behandling. Systemet skal kun ekspedere offentlige dokumenter. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>21</showOrder>
-                            <requirementText>Ved ekspedering av saksprotokoll per e-post skal vedlegg tilknyttet den
-                                politiske saken automatisk legges som vedleggsfiler til hoveddokumentet. Det må være
-                                mulig å fjerne vedlegg fra listen og legge til andre vedlegg.
-                            </requirementText>
+                            <requirementText>Ved ekspedering av saksprotokoll per e-post skal vedlegg tilknyttet den politiske saken automatisk legges som vedleggsfiler til hoveddokumentet. Det må være mulig å fjerne vedlegg fra listen og legge til andre vedlegg. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>22</showOrder>
-                            <requirementText>All ekspedering av e-post med vedlegg skal logges, slik at det er mulig å
-                                dokumentere hva som er sendt, når det er sendt og til hvem det er sendt.
-                            </requirementText>
+                            <requirementText>All ekspedering av e-post med vedlegg skal logges, slik at det er mulig å dokumentere hva som er sendt, når det er sendt og til hvem det er sendt. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>23</showOrder>
-                            <requirementText>Det bør være mulig å utføre «masseutsending» der man fra løsningen angir at
-                                mottakerne ikke skal se hvem andre e-posten er sendt til (blindkopi).
-                            </requirementText>
+                            <requirementText>Det bør være mulig å utføre «masseutsending» der man fra løsningen angir at mottakerne ikke skal se hvem andre e-posten er sendt til (blindkopi). </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>24</showOrder>
-                            <requirementText>Løsningen skal ha egne parametere for avsender av e-post. Administrator
-                                skal kunne velge hvilken adresse som skal stå som avsender på utgående e-post fra
-                                løsningen.
-                            </requirementText>
+                            <requirementText>Løsningen skal ha egne parametere for avsender av e-post. Administrator skal kunne velge hvilken adresse som skal stå som avsender på utgående e-post fra løsningen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>25</showOrder>
-                            <requirementText>Løsningen skal ha flere valg for avsender av utgående e- post. Følgende
-                                alternativer må kunne defineres: 1) Kommunens generelle e-postadresse med Reply-To
-                                kommunens generelle e-postadresse, 2) Brukers e-postadresse med Reply-To kommunens
-                                generelle e-postadresse, 3) Brukers e-postadresse med Reply-To brukers e-postadresse
-                            </requirementText>
+                            <requirementText>Løsningen skal ha flere valg for avsender av utgående e- post. Følgende alternativer må kunne defineres: 1) Kommunens generelle e-postadresse med Reply-To kommunens generelle e-postadresse, 2) Brukers e-postadresse med Reply-To kommunens generelle e-postadresse, 3) Brukers e-postadresse med Reply-To brukers e-postadresse </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -3091,132 +2115,88 @@
                 <section>
                     <sectionOrder>4</sectionOrder>
                     <sectionTitle>Krav til import / registrering av innkommet e-post</sectionTitle>
-                    <description>Kravene sikrer forventet funksjonalitet når innkommende epost skal importeres /
-                        registreres.
-                    </description>
-                    <explanation>For å kunne realisere enkelte gevinster knyttet til elektronisk arkiv og bruk av
-                        noark-system, vil det være ønskelig/nødvendig å journalføre eposter.
-                    </explanation>
-                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig, eller ikke er god nok, vil det kunne
-                        hindre effektiv dokumentfangst.
-                    </consequence>
+                    <description>Kravene sikrer forventet funksjonalitet når innkommende epost skal importeres / registreres. </description>
+                    <explanation>For å kunne realisere enkelte gevinster knyttet til elektronisk arkiv og bruk av noark-system, vil det være ønskelig/nødvendig å journalføre eposter. </explanation>
+                    <consequence>Dersom funksjonaliteten ikke er tilgjengelig, eller ikke er god nok, vil det kunne hindre effektiv dokumentfangst. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 8.4.1 (V): Informasjon fra e-posten, e-posthodet, e-postmelding og
-                                vedlegg skal på en oversiktlig måte presenteres tilrettelagt for videre registrering av
-                                hele eller deler av e-postforsendelsen.
-                            </requirementText>
+                            <requirementText>NOARK 8.4.1 (V): Informasjon fra e-posten, e-posthodet, e-postmelding og vedlegg skal på en oversiktlig måte presenteres tilrettelagt for videre registrering av hele eller deler av e-postforsendelsen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 8.4.2 (V): Det skal være mulig for saksbehandler å se innholdet i
-                                vedleggene til en e-post via en funksjon for hurtigvisning, eller med lenke til
-                                programmet som kan lese filene.
-                            </requirementText>
+                            <requirementText>NOARK 8.4.2 (V): Det skal være mulig for saksbehandler å se innholdet i vedleggene til en e-post via en funksjon for hurtigvisning, eller med lenke til programmet som kan lese filene. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 8.4.3 (V): Det skal være mulig for saksbehandler å angi hva som skal
-                                registreres som hoveddokument og hva som skal være vedlegg fra en postforsendelse.
-                            </requirementText>
+                            <requirementText>NOARK 8.4.3 (V): Det skal være mulig for saksbehandler å angi hva som skal registreres som hoveddokument og hva som skal være vedlegg fra en postforsendelse. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 8.4.4 (V): Det skal være mulig å velge at kun enkelte vedlegg til
-                                forsendelsen som mottas, skal registreres. Selve e-posten skal alltid registreres.
-                            </requirementText>
+                            <requirementText>NOARK 8.4.4 (V): Det skal være mulig å velge at kun enkelte vedlegg til forsendelsen som mottas, skal registreres. Selve e-posten skal alltid registreres. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 8.4.5 (V): Det skal være mulig å dokumentere i merknadsfelt eller
-                                lignende hvorfor enkelte vedlegg ikke arkiveres, om det skyldes dokumentformat eller
-                                andre årsaker.
-                            </requirementText>
+                            <requirementText>NOARK 8.4.5 (V): Det skal være mulig å dokumentere i merknadsfelt eller lignende hvorfor enkelte vedlegg ikke arkiveres, om det skyldes dokumentformat eller andre årsaker. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 8.4.6 (V): Det skal være mulig at det for en saksbehandler kan settes
-                                opp en systemparameter som resulterer i at saksbehandler enten automatisk blir satt som
-                                saksansvarlig ved oppretting av ny mappe, eller ikke blir satt som saksansvarlig ved
-                                oppretting av ny mappe. Det skal være mulig å overstyre dette.
-                            </requirementText>
+                            <requirementText>NOARK 8.4.6 (V): Det skal være mulig at det for en saksbehandler kan settes opp en systemparameter som resulterer i at saksbehandler enten automatisk blir satt som saksansvarlig ved oppretting av ny mappe, eller ikke blir satt som saksansvarlig ved oppretting av ny mappe. Det skal være mulig å overstyre dette. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 8.4.7 (V): Det skal være mulig at det settes opp en systemparameter
-                                som gjør at saksbehandler enten automatisk blir satt som ansvarlig saksbehandler ved
-                                oppretting av ny registrering, eller ikke blir satt som ansvarlig saksbehandler ved
-                                oppretting av ny registrering. Det skal være mulig å overstyre dette.
-                            </requirementText>
+                            <requirementText>NOARK 8.4.7 (V): Det skal være mulig at det settes opp en systemparameter som gjør at saksbehandler enten automatisk blir satt som ansvarlig saksbehandler ved oppretting av ny registrering, eller ikke blir satt som ansvarlig saksbehandler ved oppretting av ny registrering. Det skal være mulig å overstyre dette. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 8.4.8 (V): Noark 5- skal ha funksjonalitet for at det er
-                                avsenders/mottakers/kopimottakers ”display navn” (hvis det finnes) som inngår i det
-                                arkiverte dokumentet som dannes på basis av e-posthode og e-postmelding.
-                            </requirementText>
+                            <requirementText>NOARK 8.4.8 (V): Noark 5- skal ha funksjonalitet for at det er avsenders/mottakers/kopimottakers ”display navn” (hvis det finnes) som inngår i det arkiverte dokumentet som dannes på basis av e-posthode og e-postmelding. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>NOARK 8.4.9 (V): Det skal være funksjonalitet for at det er
-                                avsenders/mottakers/kopimottakers «display navn» (hvis det finnes) som inngår som
-                                avsender- / mottakermetadata i journalen.
-                            </requirementText>
+                            <requirementText>NOARK 8.4.9 (V): Det skal være funksjonalitet for at det er avsenders/mottakers/kopimottakers «display navn» (hvis det finnes) som inngår som avsender- / mottakermetadata i journalen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>NOARK 8.4.10 (V): Det skal være mulig å velge om man vil opprette en ny
-                                mappe eller bruke en eksisterende mappe via en direkte tilgjengelig funksjon under
-                                journalføring / arkivering av innkommende e-post.
-                            </requirementText>
+                            <requirementText>NOARK 8.4.10 (V): Det skal være mulig å velge om man vil opprette en ny mappe eller bruke en eksisterende mappe via en direkte tilgjengelig funksjon under journalføring / arkivering av innkommende e-post. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>NOARK 8.4.11 (V): Det skal være mulig å søke frem en mappe/ en registrering
-                                via en hurtigsøksfunksjon basert på saksnummer, avsender, dato eller emne (innhold) for
-                                å registrere e-post. Denne muligheten skal være direkte tilgjengelig som en funksjon
-                                under registrering av e-post.
-                            </requirementText>
+                            <requirementText>NOARK 8.4.11 (V): Det skal være mulig å søke frem en mappe/ en registrering via en hurtigsøksfunksjon basert på saksnummer, avsender, dato eller emne (innhold) for å registrere e-post. Denne muligheten skal være direkte tilgjengelig som en funksjon under registrering av e-post. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>Det skal være mulig for saksbehandler å angi rekkefølgen på vedlegg, samt
-                                angi hvorvidt selve e-postmeldingen importeres som vedlegg eller hoveddokument.
-                            </requirementText>
+                            <requirementText>Det skal være mulig for saksbehandler å angi rekkefølgen på vedlegg, samt angi hvorvidt selve e-postmeldingen importeres som vedlegg eller hoveddokument. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>Ved journalføring av e-post og vedlegg til e-post skal disse arve
-                                tilgangsbegrensningene som er påført journalposten.
-                            </requirementText>
+                            <requirementText>Ved journalføring av e-post og vedlegg til e-post skal disse arve tilgangsbegrensningene som er påført journalposten. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -3233,25 +2213,19 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 8.5.3 (V): Det bør være mulig å sende kopi av en mappe, det vil si
-                                alle hoveddokument og vedlegg fra alle registreringer i mappen.
-                            </requirementText>
+                            <requirementText>NOARK 8.5.3 (V): Det bør være mulig å sende kopi av en mappe, det vil si alle hoveddokument og vedlegg fra alle registreringer i mappen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 8.5.4 (V): Det skal være mulig å beholde strukturen ved en slik
-                                forsendelse slik at det er mulig å se hvilke saksdokumenter som henger sammen.
-                            </requirementText>
+                            <requirementText>NOARK 8.5.4 (V): Det skal være mulig å beholde strukturen ved en slik forsendelse slik at det er mulig å se hvilke saksdokumenter som henger sammen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 8.5.5 (V): Det skal være mulig å sende kopi og velge ut at bare
-                                hoveddokumentet sendes.
-                            </requirementText>
+                            <requirementText>NOARK 8.5.5 (V): Det skal være mulig å sende kopi og velge ut at bare hoveddokumentet sendes. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -3268,110 +2242,79 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>0</showOrder>
-                            <requirementText>Å ivareta hensyn til: 1) Tilgjengelighet – at informasjon er tilgjengelig
-                                for autoriserte brukere, 2) Konfidensialitet – at informasjon ikke skal bli kjent for
-                                uvedkommende, 3) Integritet – at informasjon ikke endres uautorisert
-                            </requirementText>
+                            <requirementText>Å ivareta hensyn til: 1) Tilgjengelighet – at informasjon er tilgjengelig for autoriserte brukere, 2) Konfidensialitet – at informasjon ikke skal bli kjent for uvedkommende, 3) Integritet – at informasjon ikke endres uautorisert </requirementText>
                             <priority></priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 8.6.2 (V): Innkommende e-post skal alltid kontrolleres opp mot de
-                                sikkerhetsmekanismer som er definert for Noark 5-løsningen.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.2 (V): Innkommende e-post skal alltid kontrolleres opp mot de sikkerhetsmekanismer som er definert for Noark 5-løsningen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 8.6.3 (V): Noark 5-løsningen skal kunne kvittere for mottatt e-post
-                                med og uten vedlegg (ut fra kvitteringsregler i løsningen).
-                            </requirementText>
+                            <requirementText>NOARK 8.6.3 (V): Noark 5-løsningen skal kunne kvittere for mottatt e-post med og uten vedlegg (ut fra kvitteringsregler i løsningen). </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 8.6.4 (V): Det skal være mulig å bruke automatisk kvittering på
-                                e-post (for eksempel idet e-post/dokument registreres).
-                            </requirementText>
+                            <requirementText>NOARK 8.6.4 (V): Det skal være mulig å bruke automatisk kvittering på e-post (for eksempel idet e-post/dokument registreres). </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 8.6.5 (V): Kvittering for at mottaker har mottatt e-posten, skal være
-                                tilgjengelig og forståelig for saksbehandler som har sendt e-posten.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.5 (V): Kvittering for at mottaker har mottatt e-posten, skal være tilgjengelig og forståelig for saksbehandler som har sendt e-posten. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 8.6.6 (V): Hvis automatisk kvittering for mottak av e-post mottak er
-                                brukt, bør det fremgå at kvitteringen er automatisk.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.6 (V): Hvis automatisk kvittering for mottak av e-post mottak er brukt, bør det fremgå at kvitteringen er automatisk. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 8.6.7 (V): Noark 5-løsningen skal ha en funksjon for å tilføre
-                                kvitteringsopplysninger (levert, åpnet/lest, feilet) fra e-postsystemet til Noark
-                                5-løsningens mottakeropplysninger på registreringen.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.7 (V): Noark 5-løsningen skal ha en funksjon for å tilføre kvitteringsopplysninger (levert, åpnet/lest, feilet) fra e-postsystemet til Noark 5-løsningens mottakeropplysninger på registreringen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 8.6.8 (V): Utgående e-post skal alltid kontrolleres opp mot de
-                                sikkerhetsmekanismer som er definert for Noark 5-løsningen.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.8 (V): Utgående e-post skal alltid kontrolleres opp mot de sikkerhetsmekanismer som er definert for Noark 5-løsningen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 8.6.9 (V): Sikkerhetsnivået i Noark 5-løsningen skal gjøre det mulig
-                                å hindre at dokumenter sendes via e-post.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.9 (V): Sikkerhetsnivået i Noark 5-løsningen skal gjøre det mulig å hindre at dokumenter sendes via e-post. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>NOARK 8.6.10 (V): Saksbehandler skal få varsel om tilgangskode og generelle
-                                begrensninger som er satt på gitte dokumenter (mapper, klasseringer) dersom disse
-                                forsøkes ekspedert per e-post.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.10 (V): Saksbehandler skal få varsel om tilgangskode og generelle begrensninger som er satt på gitte dokumenter (mapper, klasseringer) dersom disse forsøkes ekspedert per e-post. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>NOARK 8.6.11 (V): Det bør være mulig å sette opp roller og brukere av Noark
-                                5-løsningen på en slik måte at de kan overstyre sperrer mot utsendelse som er definert
-                                som standard.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.11 (V): Det bør være mulig å sette opp roller og brukere av Noark 5-løsningen på en slik måte at de kan overstyre sperrer mot utsendelse som er definert som standard. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>NOARK 8.6.12 (V): Innenfor et arkiv skal sperrer mot utsendelse kunne
-                                spesifiseres på ethvert hierarkisk nivå i arkivstrukturen. Sperrer mot utsendelse skal
-                                arves av underliggende nivå.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.12 (V): Innenfor et arkiv skal sperrer mot utsendelse kunne spesifiseres på ethvert hierarkisk nivå i arkivstrukturen. Sperrer mot utsendelse skal arves av underliggende nivå. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>NOARK 8.6.13 (V): Det bør være mulig å sette opp Noark 5-løsningen slik at
-                                skjermede dokumenter kan sendes til bestemte, predefinerte mottakere.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.13 (V): Det bør være mulig å sette opp Noark 5-løsningen slik at skjermede dokumenter kan sendes til bestemte, predefinerte mottakere. </requirementText>
                             <priority>2</priority>
                         </requirement>
                     </requirements>
@@ -3388,11 +2331,7 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 8.6.14 (V): Noark 5-løsningen bør ha sikkerhetsfunksjoner som manuelt
-                                eller automatisk kan dokumentere i ettertid når en e-post ble sendt ut fra eller kom inn
-                                til organet ut fra definerte loggingsregler i tilknytning til arkiv, arkivdel, mappe
-                                eller dokument.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.14 (V): Noark 5-løsningen bør ha sikkerhetsfunksjoner som manuelt eller automatisk kan dokumentere i ettertid når en e-post ble sendt ut fra eller kom inn til organet ut fra definerte loggingsregler i tilknytning til arkiv, arkivdel, mappe eller dokument. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -3409,27 +2348,19 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 8.6.15 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som sikrer
-                                at meldingen virkelig ble levert til adressat (proof of delivery).
-                            </requirementText>
+                            <requirementText>NOARK 8.6.15 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som sikrer at meldingen virkelig ble levert til adressat (proof of delivery). </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 8.6.16 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som kan
-                                bevise at avsender virkelig sendte aktuell e-post, selv om avsender kan ønske å benekte
-                                det (non-repudiation of origin).
-                            </requirementText>
+                            <requirementText>NOARK 8.6.16 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som kan bevise at avsender virkelig sendte aktuell e-post, selv om avsender kan ønske å benekte det (non-repudiation of origin). </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 8.6.17 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som kan
-                                bevise at avsender virkelig har mottatt aktuell e-post, selv om mottaker kan ønske å
-                                benekte det (non-repudiation of delivery).
-                            </requirementText>
+                            <requirementText>NOARK 8.6.17 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som kan bevise at avsender virkelig har mottatt aktuell e-post, selv om mottaker kan ønske å benekte det (non-repudiation of delivery). </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -3446,37 +2377,25 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 8.6.18 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som sikrer
-                                at kun adressaten skal kunne lese e-postmelding og tilhørende dokumenter (content
-                                confidentiality).
-                            </requirementText>
+                            <requirementText>NOARK 8.6.18 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som sikrer at kun adressaten skal kunne lese e-postmelding og tilhørende dokumenter (content confidentiality). </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder></showOrder>
-                            <requirementText>NOARK 8.6.19 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som kan
-                                sikre at alle brukere kan ha egen e-postadresseliste (message flow confidentiality).
-                            </requirementText>
+                            <requirementText>NOARK 8.6.19 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som kan sikre at alle brukere kan ha egen e-postadresseliste (message flow confidentiality). </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 8.6.20 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som kan
-                                sikre at ingen kan bruke andre sine e-postadresser uten å være gitt autorisasjon.
-                                (secure access management).
-                            </requirementText>
+                            <requirementText>NOARK 8.6.20 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som kan sikre at ingen kan bruke andre sine e-postadresser uten å være gitt autorisasjon. (secure access management). </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 8.6.21 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som
-                                manuelt eller automatisk kan adressere mottakere i ”blindkopi” (bcc=blind carbon copy)
-                                for utgående e-post med dokumenter ut fra definerte adresseringsregler i tilknytning til
-                                arkiv, mappe eller dokument.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.21 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som manuelt eller automatisk kan adressere mottakere i ”blindkopi” (bcc=blind carbon copy) for utgående e-post med dokumenter ut fra definerte adresseringsregler i tilknytning til arkiv, mappe eller dokument. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -3493,37 +2412,25 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 8.6.23 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som
-                                manuelt eller automatisk kan håndtere kryptering av utgående e-post med dokumenter
-                                (vedlegg) og dekryptering av innkommende e-post med dokumenter ut fra definerte
-                                krypteringsregler i tilknytning til arkiv, mappe eller dokument.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.23 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som manuelt eller automatisk kan håndtere kryptering av utgående e-post med dokumenter (vedlegg) og dekryptering av innkommende e-post med dokumenter ut fra definerte krypteringsregler i tilknytning til arkiv, mappe eller dokument. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 8.6.24 (V): Innenfor et arkiv skal regler for kryptering av
-                                dokumenter kunne spesifiseres på et hvert hierarkisk nivå i arkivstrukturen i Noark
-                                5-løsningen.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.24 (V): Innenfor et arkiv skal regler for kryptering av dokumenter kunne spesifiseres på et hvert hierarkisk nivå i arkivstrukturen i Noark 5-løsningen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 8.6.25 (V): Regler for kryptering av dokumenter skal arves av
-                                underliggende nivå i arkivstrukturen.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.25 (V): Regler for kryptering av dokumenter skal arves av underliggende nivå i arkivstrukturen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 8.6.26 (V): Det skal være mulig å kunne sette opp både roller og
-                                brukere av Noark 5-løsningen på en slik måte at de kan overstyre reglene for kryptering
-                                ved forsendelse som er definert som standard.
-                            </requirementText>
+                            <requirementText>NOARK 8.6.26 (V): Det skal være mulig å kunne sette opp både roller og brukere av Noark 5-løsningen på en slik måte at de kan overstyre reglene for kryptering ved forsendelse som er definert som standard. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -3540,29 +2447,19 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 8.6.27 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som
-                                manuelt eller automatisk kan digitalt signere utgående e-post med dokumenter ut fra
-                                definerte signeringsregler i tilknytning til arkiv, mappe, eller dokument
-                                (”authenticity”)
-                            </requirementText>
+                            <requirementText>NOARK 8.6.27 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som manuelt eller automatisk kan digitalt signere utgående e-post med dokumenter ut fra definerte signeringsregler i tilknytning til arkiv, mappe, eller dokument (”authenticity”) </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 8.6.28 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som kan
-                                verifisere at avsender av en innkommende e-post er den han utgir seg for å være
-                                (”authenticity”).
-                            </requirementText>
+                            <requirementText>NOARK 8.6.28 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som kan verifisere at avsender av en innkommende e-post er den han utgir seg for å være (”authenticity”). </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 8.6.29 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som kan
-                                verifisere at dokumentene ikke er endret etter ekspedering via e-post (content
-                                integrity).
-                            </requirementText>
+                            <requirementText>NOARK 8.6.29 (V): Noark 5-løsningen skal ha sikkerhetsfunksjoner som kan verifisere at dokumentene ikke er endret etter ekspedering via e-post (content integrity). </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -3576,32 +2473,22 @@
                 <section>
                     <sectionOrder>1</sectionOrder>
                     <sectionTitle>Krav til utvalgsbehandling – administrativ sak</sectionTitle>
-                    <description>Dette kapittelet beskriver generelle krav til funksjonalitet mellom sak/arkivsystem og
-                        utvalgsbehandling.
-                    </description>
-                    <explanation>Det som registreres i sak/arkivsystem skal overføres til utvalgsbehandling slik at man
-                        skal slippe å registrere informasjon på nytt.
-                    </explanation>
-                    <consequence>Dette forenkler utvalgsbehandlingen, og gjør saksarkivet oppdatert med hensyn til
-                        informasjon rundt saker som er politisk behandlet.
-                    </consequence>
+                    <description>Dette kapittelet beskriver generelle krav til funksjonalitet mellom sak/arkivsystem og utvalgsbehandling. </description>
+                    <explanation>Det som registreres i sak/arkivsystem skal overføres til utvalgsbehandling slik at man skal slippe å registrere informasjon på nytt. </explanation>
+                    <consequence>Dette forenkler utvalgsbehandlingen, og gjør saksarkivet oppdatert med hensyn til informasjon rundt saker som er politisk behandlet. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 9.3.1 (V): Det skal finnes funksjoner for at en møtesak skal kunne
-                                hente all informasjon om saken fra den administrative saken.
-                            </requirementText>
+                            <requirementText>NOARK 9.3.1 (V): Det skal finnes funksjoner for at en møtesak skal kunne hente all informasjon om saken fra den administrative saken. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 9.3.2 (V): Det skal være mulig å angi at saksframlegget må være
-                                ferdig utarbeidet av saksbehandler før saken meldes til beslutningsorganet.
-                            </requirementText>
+                            <requirementText>NOARK 9.3.2 (V): Det skal være mulig å angi at saksframlegget må være ferdig utarbeidet av saksbehandler før saken meldes til beslutningsorganet. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -3618,78 +2505,55 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>Løsningen skal registrere og styre saksgangen i alle saker som skal
-                                behandles i ett eller flere politiske organer.
-                            </requirementText>
+                            <requirementText>Løsningen skal registrere og styre saksgangen i alle saker som skal behandles i ett eller flere politiske organer. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>Løsningen skal vise hvilken status ulike saker har fra de blir meldt opp
-                                til behandling, til de er behandlet i avsluttende politisk organ og sendt tilbake til
-                                administrasjonen.
-                            </requirementText>
+                            <requirementText>Løsningen skal vise hvilken status ulike saker har fra de blir meldt opp til behandling, til de er behandlet i avsluttende politisk organ og sendt tilbake til administrasjonen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>Det skal være mulig å produsere sakskart til politiske organer. Vedlegg
-                                skal enkelt kunne knyttes til sakskartet.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å produsere sakskart til politiske organer. Vedlegg skal enkelt kunne knyttes til sakskartet. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>Det skal være mulig å produsere samlet saksframstilling og melding om
-                                vedtak. Samlet saksframstilling skal ligge etter siste politiske behandling,etter dato.
-                                Saksprotokoller, samlet saksframstilling og melding om vedtak skal legges i den arkivsak
-                                de tilhører, og det skal fremgå hvem som har produsert dokumentene.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å produsere samlet saksframstilling og melding om vedtak. Samlet saksframstilling skal ligge etter siste politiske behandling,etter dato. Saksprotokoller, samlet saksframstilling og melding om vedtak skal legges i den arkivsak de tilhører, og det skal fremgå hvem som har produsert dokumentene. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>Sidedeling i saksframlegg skal være lik sidedeling i sakspapirene
-                                (dokumentmaler i samme størrelse).
-                            </requirementText>
+                            <requirementText>Sidedeling i saksframlegg skal være lik sidedeling i sakspapirene (dokumentmaler i samme størrelse). </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>Saksframlegg skal bare kunne produseres fra den administrative
-                                saksmappen.
-                            </requirementText>
+                            <requirementText>Saksframlegg skal bare kunne produseres fra den administrative saksmappen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>Det skal være enkelt å hente dokumenter fra den administrative saken som
-                                vedlegg i den politiske saken. Dokumentene skal da automatisk konverteres til PDF/A
-                            </requirementText>
+                            <requirementText>Det skal være enkelt å hente dokumenter fra den administrative saken som vedlegg i den politiske saken. Dokumentene skal da automatisk konverteres til PDF/A </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>Administrative saker skal kunne endres fra delegert behandling til politisk
-                                behandling (Det motsatte må også være mulig).
-                            </requirementText>
+                            <requirementText>Administrative saker skal kunne endres fra delegert behandling til politisk behandling (Det motsatte må også være mulig). </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>Uregistrerte saker skal i størst mulig grad kunne knyttes til den
-                                virksomhet/avdeling som det er naturlig å knytte den til. Leverandøren skal beskrive
-                                hvordan problematikk knyttet til uregistrerte / etteranmeldte saker til utvalg håndteres
-                                i løsningen.
-                            </requirementText>
+                            <requirementText>Uregistrerte saker skal i størst mulig grad kunne knyttes til den virksomhet/avdeling som det er naturlig å knytte den til. Leverandøren skal beskrive hvordan problematikk knyttet til uregistrerte / etteranmeldte saker til utvalg håndteres i løsningen. </requirementText>
                             <priority>2 (i)</priority>
                         </requirement>
                     </requirements>
@@ -3697,169 +2561,124 @@
                 <section>
                     <sectionOrder>3</sectionOrder>
                     <sectionTitle>Krav til utvalgsbehandling – administrere beslutningsorgan</sectionTitle>
-                    <description>Kapittelet omhandler administrasjon av beslutningsorganer: Man skal kunne opprette,
-                        legge ned organer og medlemmer/varamedlemmer, opplysninger rundt organer og medlemmer. Alle
-                        registreringer skal logges, og det skal være mulig å lagre historikk.
-                    </description>
-                    <explanation>Man skal ha mulighet for å opprette og vedlikeholde alle styrer, råd og utvalg samt
-                        disses medlemmer. All historikk skal finnes og endringer skal loggføres.
-                    </explanation>
-                    <consequence>Ved ikke å ha denne funksjonaliteten kan man ikke opprette og vedlikeholde styrer, råd
-                        og utvalg og deres medlemmer, samt avslutte beslutningsorganer i organisasjonen.
-                    </consequence>
+                    <description>Kapittelet omhandler administrasjon av beslutningsorganer: Man skal kunne opprette, legge ned organer og medlemmer/varamedlemmer, opplysninger rundt organer og medlemmer. Alle registreringer skal logges, og det skal være mulig å lagre historikk. </description>
+                    <explanation>Man skal ha mulighet for å opprette og vedlikeholde alle styrer, råd og utvalg samt disses medlemmer. All historikk skal finnes og endringer skal loggføres. </explanation>
+                    <consequence>Ved ikke å ha denne funksjonaliteten kan man ikke opprette og vedlikeholde styrer, råd og utvalg og deres medlemmer, samt avslutte beslutningsorganer i organisasjonen. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 9.4.1 (V): Det skal finnes en funksjon for oppretting, endring og
-                                nedleggelse av beslutningsorganer. Endringer skal logges.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.1 (V): Det skal finnes en funksjon for oppretting, endring og nedleggelse av beslutningsorganer. Endringer skal logges. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 9.4.2 (V): Det skal være mulig å innordne et beslutningsorgan i
-                                organisasjonsstrukturen.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.2 (V): Det skal være mulig å innordne et beslutningsorgan i organisasjonsstrukturen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 9.4.3 (V): Det skal være mulig å kunne tilknytte beslutningsorganet
-                                til den administrative strukturen i Noark5.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.3 (V): Det skal være mulig å kunne tilknytte beslutningsorganet til den administrative strukturen i Noark5. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 9.4.4 (V): Det skal være mulig å tilordne representanter og
-                                vararepresentanter i et beslutningsorgan.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.4 (V): Det skal være mulig å tilordne representanter og vararepresentanter i et beslutningsorgan. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 9.4.5 (V): Det skal være mulig å registrere opplysninger om
-                                representanter og vararepresentanter i et beslutningsorgan.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.5 (V): Det skal være mulig å registrere opplysninger om representanter og vararepresentanter i et beslutningsorgan. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 9.4.6 (V): Det skal være mulig å hente fram opplysninger om
-                                representanter og vararepresentanter i et beslutningsorgan.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.6 (V): Det skal være mulig å hente fram opplysninger om representanter og vararepresentanter i et beslutningsorgan. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 9.4.7 (V): Det skal være mulig å endre opplysninger om representanter
-                                og vararepresentanter i et beslutningsorgan. Endringene skal logges.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.7 (V): Det skal være mulig å endre opplysninger om representanter og vararepresentanter i et beslutningsorgan. Endringene skal logges. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 9.4.8 (V): Det skal være mulig å registrere dato for representanter
-                                og vararepresentanters inntreden i et beslutningsorgan.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.8 (V): Det skal være mulig å registrere dato for representanter og vararepresentanters inntreden i et beslutningsorgan. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>NOARK 9.4.9 (V): Det skal finnes tjenester/funksjoner for å registrere dato
-                                for representanter og vararepresentanters uttreden fra et beslutningsorgan.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.9 (V): Det skal finnes tjenester/funksjoner for å registrere dato for representanter og vararepresentanters uttreden fra et beslutningsorgan. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>NOARK 9.4.10 (V): Det skal ikke være mulig å slette opplysninger om
-                                representanter og vararepresentanter som er eller har vært medlemmer av et fungerende
-                                beslutningsorgan.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.10 (V): Det skal ikke være mulig å slette opplysninger om representanter og vararepresentanter som er eller har vært medlemmer av et fungerende beslutningsorgan. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>NOARK 9.4.11 (V): Det skal være mulig å tilordne roller til representanter
-                                i beslutningsorganet (leder, nestleder, sekretær osv.)
-                            </requirementText>
+                            <requirementText>NOARK 9.4.11 (V): Det skal være mulig å tilordne roller til representanter i beslutningsorganet (leder, nestleder, sekretær osv.) </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>NOARK 9.4.12 (V): Det skal være mulig å lagre historikk over hvem som har
-                                vært medlemmer / deltatt i ulike utvalg og verv.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.12 (V): Det skal være mulig å lagre historikk over hvem som har vært medlemmer / deltatt i ulike utvalg og verv. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>13</showOrder>
-                            <requirementText>NOARK 9.4.13 (V): Det skal finnes tjenester/funksjoner for å hente fram et
-                                eller flere beslutningsorgan.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.13 (V): Det skal finnes tjenester/funksjoner for å hente fram et eller flere beslutningsorgan. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>14</showOrder>
-                            <requirementText>NOARK 9.4.14 (V): Det skal skal være mulig å registrere dato for
-                                opprettelse av et beslutningsorgan.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.14 (V): Det skal skal være mulig å registrere dato for opprettelse av et beslutningsorgan. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>15</showOrder>
-                            <requirementText>NOARK 9.4.15 (V): Det skal være mulig å registrere dato for nedleggelse av
-                                et beslutningsorgan.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.15 (V): Det skal være mulig å registrere dato for nedleggelse av et beslutningsorgan. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>16</showOrder>
-                            <requirementText>NOARK 9.4.16 (V): Det skal ikke være mulig å slette et beslutningsorgan som
-                                er eller har vært i funksjon.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.16 (V): Det skal ikke være mulig å slette et beslutningsorgan som er eller har vært i funksjon. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>17</showOrder>
-                            <requirementText>Fra registeret over politikere skal det kunne tas ut adresse-etiketter.
-                            </requirementText>
+                            <requirementText>Fra registeret over politikere skal det kunne tas ut adresse-etiketter. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>18</showOrder>
-                            <requirementText>Registeret (over politikere) skal være en del av systemets adresseregister
-                                (ajourhold skal skje kun ett sted).
-                            </requirementText>
+                            <requirementText>Registeret (over politikere) skal være en del av systemets adresseregister (ajourhold skal skje kun ett sted). </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>falsen</noarkRequirement>
                             <showOrder>19</showOrder>
-                            <requirementText>Det skal kunne registreres hvem som deltar på det enkelte møtet. Det skal
-                                kunne tas ut rapport på hver enkelt deltaker som viser hvilke møter denne har deltatt i.
-                            </requirementText>
+                            <requirementText>Det skal kunne registreres hvem som deltar på det enkelte møtet. Det skal kunne tas ut rapport på hver enkelt deltaker som viser hvilke møter denne har deltatt i. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -3867,89 +2686,64 @@
                 <section>
                     <sectionOrder>4</sectionOrder>
                     <sectionTitle>Krav til utvalgsbehandling – forberede møte</sectionTitle>
-                    <description>Kravene i dette kapitlet er ment å sikre funksjonalitet rundt forberedelser av møter i
-                        de ulike besluttningsorgan. Det bør også være muligheter for oppretting av tilleggssaker.
-                    </description>
-                    <explanation>Ved å kunne registrere møtedatoer, medlemmer, varamedlemmer, møteinnkalling, innkalling
-                        av varamedlemmer m.v. administreres beslutningsorgan enklere.
-                    </explanation>
-                    <consequence>Hvis man ikke gjør registreringer rundt beslutningsorganene i fortid, vil man måtte
-                        gjøre disse før hvert møte.
-                    </consequence>
+                    <description>Kravene i dette kapitlet er ment å sikre funksjonalitet rundt forberedelser av møter i de ulike besluttningsorgan. Det bør også være muligheter for oppretting av tilleggssaker. </description>
+                    <explanation>Ved å kunne registrere møtedatoer, medlemmer, varamedlemmer, møteinnkalling, innkalling av varamedlemmer m.v. administreres beslutningsorgan enklere. </explanation>
+                    <consequence>Hvis man ikke gjør registreringer rundt beslutningsorganene i fortid, vil man måtte gjøre disse før hvert møte. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 9.4.17 (V): Det skal være mulig å fastsette møter fram i tid.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.17 (V): Det skal være mulig å fastsette møter fram i tid. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 9.4.18 (V): Det skal finnes en funksjon for å sette sammen sakliste
-                                ut fra saksframlegg og vedlegg som er lagret på saken.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.18 (V): Det skal finnes en funksjon for å sette sammen sakliste ut fra saksframlegg og vedlegg som er lagret på saken. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 9.4.19 (V): Det skal være mulig å kunne merke at en sak til møtet
-                                skal være lukket, dvs. gå for lukkede dører.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.19 (V): Det skal være mulig å kunne merke at en sak til møtet skal være lukket, dvs. gå for lukkede dører. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 9.4.20 (V): Det skal være mulig å sette opp en behandlingsprosess for
-                                hver sak som skal behandles, dvs. hvilke beslutningsorganer saken skal opp i. Dette skal
-                                komme fram i sakspapirene til hver sak.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.20 (V): Det skal være mulig å sette opp en behandlingsprosess for hver sak som skal behandles, dvs. hvilke beslutningsorganer saken skal opp i. Dette skal komme fram i sakspapirene til hver sak. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 9.4.21 (V): Det skal finnes en funksjon for å håndtere
-                                vararepresentanter for ordinære representanter som ikke kan møte.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.21 (V): Det skal finnes en funksjon for å håndtere vararepresentanter for ordinære representanter som ikke kan møte. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 9.4.22 (V): Det skal finnes en funksjon for å sende ut innkalling til
-                                alle møtedeltakerne.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.22 (V): Det skal finnes en funksjon for å sende ut innkalling til alle møtedeltakerne. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>Melding om at sakskart, saksframlegg og vedlegg som er lagt ut på kommunens
-                                internettsider skal automatisk sendes til utvalgets medlemmer, varamedlemmer og
-                                abonnenter.
-                            </requirementText>
+                            <requirementText>Melding om at sakskart, saksframlegg og vedlegg som er lagt ut på kommunens internettsider skal automatisk sendes til utvalgets medlemmer, varamedlemmer og abonnenter. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>Vedlegg skal legge seg etter saken de tilhører når sakspapirer blir
-                                flettet.
-                            </requirementText>
+                            <requirementText>Vedlegg skal legge seg etter saken de tilhører når sakspapirer blir flettet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>Det skal være mulig å melde opp tilleggssaker / produsere
-                                tilleggssakspapirer etter at sakspapirene er ferdige.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å melde opp tilleggssaker / produsere tilleggssakspapirer etter at sakspapirene er ferdige. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -3958,73 +2752,51 @@
                     <sectionOrder>5</sectionOrder>
                     <sectionTitle>Krav til utvalgsbehandling – selve møtet</sectionTitle>
                     <description>Kapittelet beskriver registreringer under møtet.</description>
-                    <explanation>Det skal være mulig for eks. utvalgssekretær å registrere forslag, avstemminger og
-                        vedtaksprotokoll under møtet. Protokoller skal journalføres i sakene i sakssystemet.
-                    </explanation>
-                    <consequence>Ved å ikke ha denne funksjonaliteten i møtet, vil etterarbeidet bli større og ta lengre
-                        tid.
-                    </consequence>
+                    <explanation>Det skal være mulig for eks. utvalgssekretær å registrere forslag, avstemminger og vedtaksprotokoll under møtet. Protokoller skal journalføres i sakene i sakssystemet. </explanation>
+                    <consequence>Ved å ikke ha denne funksjonaliteten i møtet, vil etterarbeidet bli større og ta lengre tid. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 9.4.23 (V): Det skal være mulig for at autoriserte roller eller
-                                personer å registrere vedtak underveis i møtet.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.23 (V): Det skal være mulig for at autoriserte roller eller personer å registrere vedtak underveis i møtet. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 9.4.24 (V): Det skal finnes en funksjon for at vedtak som blir
-                                registrert underveis i møtet, blir lagret i tilknytning til saken som
-                                informasjonselementer av typen MV («møtevedtak»).
-                            </requirementText>
+                            <requirementText>NOARK 9.4.24 (V): Det skal finnes en funksjon for at vedtak som blir registrert underveis i møtet, blir lagret i tilknytning til saken som informasjonselementer av typen MV («møtevedtak»). </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 9.4.25 (V): Det skal finnes en funksjon for at vedtak som blir
-                                registrert underveis i møtet, blir lagret i tilknytning til saken med status «ikke
-                                godkjent vedtak».
-                            </requirementText>
+                            <requirementText>NOARK 9.4.25 (V): Det skal finnes en funksjon for at vedtak som blir registrert underveis i møtet, blir lagret i tilknytning til saken med status «ikke godkjent vedtak». </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 9.4.26 (V): Det skal finnes en funksjon for at et vedtaksdokument får
-                                status som «godkjent vedtak» når protokollen er godkjent i henhold til
-                                godkjenningsrutinene.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.26 (V): Det skal finnes en funksjon for at et vedtaksdokument får status som «godkjent vedtak» når protokollen er godkjent i henhold til godkjenningsrutinene. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>I utkast til møteprotokoll skal det kunne registreres hvilke forslag som
-                                fremmes, avstemmingsresultat og utvalgets vedtak.
-                            </requirementText>
+                            <requirementText>I utkast til møteprotokoll skal det kunne registreres hvilke forslag som fremmes, avstemmingsresultat og utvalgets vedtak. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>Saksprotokoll for den enkelte sak skal kunne produseres i møtet og
-                                overføres til kommunens internettsider. Se også krav til publisering av offentlige
-                                dokumenter.
-                            </requirementText>
+                            <requirementText>Saksprotokoll for den enkelte sak skal kunne produseres i møtet og overføres til kommunens internettsider. Se også krav til publisering av offentlige dokumenter. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>Saksprotokoll skal registreres som egen journalpost i arkivsystemet og være
-                                lett tilgjengelig fra utvalgsbehandlingen.
-                            </requirementText>
+                            <requirementText>Saksprotokoll skal registreres som egen journalpost i arkivsystemet og være lett tilgjengelig fra utvalgsbehandlingen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -4032,85 +2804,58 @@
                 <section>
                     <sectionOrder>6</sectionOrder>
                     <sectionTitle>Krav til utvalgsbehandling – etter møtet</sectionTitle>
-                    <description>Dette kapittelet beskriver etterarbeidet etter møtet, registreringer av fremmøte og
-                        utbetaling av møtegodtgjørelse.
-                    </description>
-                    <explanation>Autoriserte brukere skal kunne gjøre endringer i tekst, hente fram rapporter over
-                        frammøte for utbetaling av møtegodtgjørelse, knytte til interpellasjoner m.v. etter at møtet er
-                        avsluttet.
-                    </explanation>
-                    <consequence>Protokoller må være i henhold til hva som faktisk skjedde i møtet, og må kunne
-                        redigeres. Har man frammøte knyttet opp mot møtegodtgjøring, forenkles også denne delen av
-                        arbeidet.
-                    </consequence>
+                    <description>Dette kapittelet beskriver etterarbeidet etter møtet, registreringer av fremmøte og utbetaling av møtegodtgjørelse. </description>
+                    <explanation>Autoriserte brukere skal kunne gjøre endringer i tekst, hente fram rapporter over frammøte for utbetaling av møtegodtgjørelse, knytte til interpellasjoner m.v. etter at møtet er avsluttet. </explanation>
+                    <consequence>Protokoller må være i henhold til hva som faktisk skjedde i møtet, og må kunne redigeres. Har man frammøte knyttet opp mot møtegodtgjøring, forenkles også denne delen av arbeidet. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 9.4.27 (V): Det skal finnes en funksjon som tillater
-                                beslutningsorganets medlemmer å komme med en samlet merknad til protokollen innen en
-                                definert tidsfrist.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.27 (V): Det skal finnes en funksjon som tillater beslutningsorganets medlemmer å komme med en samlet merknad til protokollen innen en definert tidsfrist. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 9.4.28 (V): Det skal finnes en funksjon som tillater
-                                beslutningsorganets medlemmer å komme med individuelle merknader til protokollen innen
-                                en definert tidsfrist.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.28 (V): Det skal finnes en funksjon som tillater beslutningsorganets medlemmer å komme med individuelle merknader til protokollen innen en definert tidsfrist. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 9.4.29 (V): Det skal finnes en funksjon som tillater registrering av
-                                godkjenning av protokollen.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.29 (V): Det skal finnes en funksjon som tillater registrering av godkjenning av protokollen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 9.4.30 (V): Det skal finnes en funksjon som tillater registrering av
-                                den enkelte møtedeltakers godkjenning / ikke godkjenning av protokollen.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.30 (V): Det skal finnes en funksjon som tillater registrering av den enkelte møtedeltakers godkjenning / ikke godkjenning av protokollen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>Bare brukere som er definert som møtesekretærer i administrator skal gjøre
-                                registreringer i/endringer i alle dokumenter tilknyttet utvalgsbehandlingen fra en sak
-                                blir satt på sakskartet til den blir tilbakesendt saksbehandler/administrasjonen.
-                            </requirementText>
+                            <requirementText>Bare brukere som er definert som møtesekretærer i administrator skal gjøre registreringer i/endringer i alle dokumenter tilknyttet utvalgsbehandlingen fra en sak blir satt på sakskartet til den blir tilbakesendt saksbehandler/administrasjonen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>Ved endring av tekst i møteprotokoll skal endringen automatisk skje i
-                                saksprotokoll.
-                            </requirementText>
+                            <requirementText>Ved endring av tekst i møteprotokoll skal endringen automatisk skje i saksprotokoll. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>Det skal være mulig å hente rapport over fremmøte og utbetaling av
-                                møtegodtgjørelse.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å hente rapport over fremmøte og utbetaling av møtegodtgjørelse. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>Interpellasjoner som foreligger fra et utvalgsmedlem eller parti må kunne
-                                registreres som egen sakstype med mulighet for senere å knytte denne til en arkivsak.
-                            </requirementText>
+                            <requirementText>Interpellasjoner som foreligger fra et utvalgsmedlem eller parti må kunne registreres som egen sakstype med mulighet for senere å knytte denne til en arkivsak. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -4118,194 +2863,142 @@
                 <section>
                     <sectionOrder>7</sectionOrder>
                     <sectionTitle>Krav til utvalgsbehandling – administrasjon av møtebehandlingen</sectionTitle>
-                    <description>Kapittelet beskriver funksjonaliteter knyttet opp mot møtebehandling i
-                        sak/arkivsystemet.
-                    </description>
-                    <explanation>Her beskrives de ulike funksjonaliteter som må være tilstede for å opprette, innkalle
-                        medlemmer, gjennomføre møtet og protokollere, registrere i hvilke utvalg saker har blitt
-                        behandlet i og i hvilken rekkefølge, offentlige og unntatt offentlige varianter; hvilken sendes
-                        til publisering, logging av hendelser osv.
-                    </explanation>
-                    <consequence>Dette er helt nødvendige funksjonaliteter for å kunne administrere
-                        utvalgsbehandlingen.
-                    </consequence>
+                    <description>Kapittelet beskriver funksjonaliteter knyttet opp mot møtebehandling i sak/arkivsystemet. </description>
+                    <explanation>Her beskrives de ulike funksjonaliteter som må være tilstede for å opprette, innkalle medlemmer, gjennomføre møtet og protokollere, registrere i hvilke utvalg saker har blitt behandlet i og i hvilken rekkefølge, offentlige og unntatt offentlige varianter; hvilken sendes til publisering, logging av hendelser osv. </explanation>
+                    <consequence>Dette er helt nødvendige funksjonaliteter for å kunne administrere utvalgsbehandlingen. </consequence>
                     <type>submenu</type>
                     <showMe>true</showMe>
                     <requirements>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 9.4.31 (V): Det skal være mulig å loggføre hvilke behandlingsnivåer
-                                som har behandlet en Møtemappe eller Møteregistrering.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.31 (V): Det skal være mulig å loggføre hvilke behandlingsnivåer som har behandlet en Møtemappe eller Møteregistrering. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 9.4.32 (V): Alle informasjonselementer i møtebehandlingen skal ha
-                                tilgjengelig informasjon om hvilken status elementet har i saksbehandlingsprosessen.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.32 (V): Alle informasjonselementer i møtebehandlingen skal ha tilgjengelig informasjon om hvilken status elementet har i saksbehandlingsprosessen. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 9.4.33 (V): Det skal ikke være mulig å registrere møtebehandling for
-                                et beslutningsorgan som er avsluttet.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.33 (V): Det skal ikke være mulig å registrere møtebehandling for et beslutningsorgan som er avsluttet. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 9.4.34 (V): Det skal finnes en funksjon for å lage saksliste.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.34 (V): Det skal finnes en funksjon for å lage saksliste. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 9.4.35 (V): Det skal finnes en funksjon for å hente frem [en allerede
-                                produsert] saksliste.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.35 (V): Det skal finnes en funksjon for å hente frem [en allerede produsert] saksliste. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 9.4.36 (V): Det skal være mulig å endre saksliste fram til
-                                møtetidspunkt. Endringene skal logges.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.36 (V): Det skal være mulig å endre saksliste fram til møtetidspunkt. Endringene skal logges. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 9.4.37 (V): Det skal ikke være mulig å endre saksliste etter at møtet
-                                er avsluttet.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.37 (V): Det skal ikke være mulig å endre saksliste etter at møtet er avsluttet. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 9.4.38 (V): Det skal ikke være mulig å slette saksliste etter at
-                                møtet er avsluttet.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.38 (V): Det skal ikke være mulig å slette saksliste etter at møtet er avsluttet. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>NOARK 9.4.39 (V): Det skal være en funksjon for å hente saksframlegg og
-                                vedlegg.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.39 (V): Det skal være en funksjon for å hente saksframlegg og vedlegg. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>NOARK 9.4.41 (V): Det skal ikke være mulig å slette saksframlegg og vedlegg
-                                etter at møtet er avsluttet.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.41 (V): Det skal ikke være mulig å slette saksframlegg og vedlegg etter at møtet er avsluttet. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>NOARK 9.4.42 (V): Det skal finnes en funksjon for å sende møteinnkalling
-                                til møtedeltakerne.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.42 (V): Det skal finnes en funksjon for å sende møteinnkalling til møtedeltakerne. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>NOARK 9.4.43 (V): Det skal finnes en funksjon for å produsere
-                                saksprotokoller.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.43 (V): Det skal finnes en funksjon for å produsere saksprotokoller. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>13</showOrder>
-                            <requirementText>NOARK 9.4.44 (V): Det skal være mulig å endre saksprotokoller før de er
-                                godkjent.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.44 (V): Det skal være mulig å endre saksprotokoller før de er godkjent. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>14</showOrder>
-                            <requirementText>NOARK 9.4.45 (V): Det skal ikke være mulig å endre saksprotokoller etter at
-                                de er godkjent.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.45 (V): Det skal ikke være mulig å endre saksprotokoller etter at de er godkjent. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>15</showOrder>
-                            <requirementText>NOARK 9.4.46 (V): Det skal finnes en funksjon som sikrer at saksprotokoller
-                                automatisk kan knyttes til den saken der den har sitt utspring.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.46 (V): Det skal finnes en funksjon som sikrer at saksprotokoller automatisk kan knyttes til den saken der den har sitt utspring. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>16</showOrder>
-                            <requirementText>NOARK 9.4.47 (V): Det skal ikke være mulig å slette saksprotokoller som er
-                                godkjent.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.47 (V): Det skal ikke være mulig å slette saksprotokoller som er godkjent. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>17</showOrder>
-                            <requirementText>NOARK 9.4.48 (V): Det skal ikke være mulig å slette en møtebok.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.48 (V): Det skal ikke være mulig å slette en møtebok. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>18</showOrder>
-                            <requirementText>NOARK 9.4.49 (V): Det skal finnes en funksjon for å lage en offentlig
-                                variant av en møtebok, ved at taushetsbelagte opplysninger og opplysninger unntatt
-                                offentlighet skjermes.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.49 (V): Det skal finnes en funksjon for å lage en offentlig variant av en møtebok, ved at taushetsbelagte opplysninger og opplysninger unntatt offentlighet skjermes. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>19</showOrder>
-                            <requirementText>NOARK 9.4.50 (V): Det skal finnes en funksjon for å publisere den
-                                offentlige varianten av møteboken på internett. (se også krav til publisering av
-                                offentlige dokumenter)
-                            </requirementText>
+                            <requirementText>NOARK 9.4.50 (V): Det skal finnes en funksjon for å publisere den offentlige varianten av møteboken på internett. (se også krav til publisering av offentlige dokumenter) </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>20</showOrder>
-                            <requirementText>NOARK 9.4.51 (V): Det skal finnes en funksjon for å journalføre og arkivere
-                                den offentlige varianten av møteboken
-                            </requirementText>
+                            <requirementText>NOARK 9.4.51 (V): Det skal finnes en funksjon for å journalføre og arkivere den offentlige varianten av møteboken </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>21</showOrder>
-                            <requirementText>NOARK 9.4.52 (V): Det skal finnes en funksjon for å avslutte en møtesak.
-                            </requirementText>
+                            <requirementText>NOARK 9.4.52 (V): Det skal finnes en funksjon for å avslutte en møtesak. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>22</showOrder>
-                            <requirementText>Det skal være mulig å produsere sakskart til overordnet politisk organ.
-                                Sakskartet skal vise behandling og vedtak fra tidligere politiske behandlinger og
-                                forslag til vedtak.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å produsere sakskart til overordnet politisk organ. Sakskartet skal vise behandling og vedtak fra tidligere politiske behandlinger og forslag til vedtak. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -4323,96 +3016,73 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Løsningen skal inneholde en byggesaksmodul. Byggesaksmodulen skal være
-                            oppdatert i henhold til gjeldende Plan- og bygningslov, inkl revisjon av 1.juli 2015.
-                        </requirementText>
+                        <requirementText>Løsningen skal inneholde en byggesaksmodul. Byggesaksmodulen skal være oppdatert i henhold til gjeldende Plan- og bygningslov, inkl revisjon av 1.juli 2015. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Løsningen skal inneholde predefinerte registreringsfelter for sakstypene bygg,
-                            plan og deling.
-                        </requirementText>
+                        <requirementText>Løsningen skal inneholde predefinerte registreringsfelter for sakstypene bygg, plan og deling. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Løsningen skal inneholde mulighet for predefinerte registreringsfelter for
-                            sakstype VAR, Geodata og landbruk.
-                        </requirementText>
+                        <requirementText>Løsningen skal inneholde mulighet for predefinerte registreringsfelter for sakstype VAR, Geodata og landbruk. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>Løsningen skal ha mulighet for egendefinisjon av milepæler/frister.
-                        </requirementText>
+                        <requirementText>Løsningen skal ha mulighet for egendefinisjon av milepæler/frister. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Status for saksflyt i byggesaksbehandlingen skal vises i saksgang som
-                            inneholder mer enn 2 arbeidsflyter (milepæler). Status for saksflyt skal vises i kartet
-                            eventuelt i innsynsmodulen.
-                        </requirementText>
+                        <requirementText>Status for saksflyt i byggesaksbehandlingen skal vises i saksgang som inneholder mer enn 2 arbeidsflyter (milepæler). Status for saksflyt skal vises i kartet eventuelt i innsynsmodulen. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>6</showOrder>
-                        <requirementText>«Forenklet tjenestegrensesnitt i henhold til geointegrasjon skal inngå i
-                            byggesaksmodulen, jf kap 10.2».
-                        </requirementText>
+                        <requirementText>«Forenklet tjenestegrensesnitt i henhold til geointegrasjon skal inngå i byggesaksmodulen, jf kap 10.2». </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>7</showOrder>
-                        <requirementText>Løsningen skal ha funksjonalitet for visning av eiendom i kartutsnitt. Jf Kap
-                            10.2
-                        </requirementText>
+                        <requirementText>Løsningen skal ha funksjonalitet for visning av eiendom i kartutsnitt. Jf Kap 10.2 </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>8</showOrder>
-                        <requirementText>Løsningen skal gi mulighet for å hente digital adresseliste fra
-                            matrikkel/kartsystemer (via geointegrasjon)
-                        </requirementText>
+                        <requirementText>Løsningen skal gi mulighet for å hente digital adresseliste fra matrikkel/kartsystemer (via geointegrasjon) </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>9</showOrder>
-                        <requirementText>Byggesaksmodulen skal kunne gi mulighet for føring av de metadata som skal
-                            føres i matrikkelen. Dataene skal være søkbare.
-                        </requirementText>
+                        <requirementText>Byggesaksmodulen skal kunne gi mulighet for føring av de metadata som skal føres i matrikkelen. Dataene skal være søkbare. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>10</showOrder>
-                        <requirementText>Løsningen skal ha mulighet til å registrere flere eiendommer i en sak.
-                        </requirementText>
+                        <requirementText>Løsningen skal ha mulighet til å registrere flere eiendommer i en sak. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>11</showOrder>
-                        <requirementText>Løsningen skal være kompatibel med digital søknad fra eksterne leverandører.
-                            Eksempelvis (byggsøk, E-søknad, elektroniske skjema fra K24:7/ DIBK sin løsning)
-                        </requirementText>
+                        <requirementText>Løsningen skal være kompatibel med digital søknad fra eksterne leverandører. Eksempelvis (byggsøk, E-søknad, elektroniske skjema fra K24:7/ DIBK sin løsning) </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>12</showOrder>
-                        <requirementText>Løsningen skal være mulig å integrere mot andre innsynsløsninger enn
-                            leverandørens egen løsning.
-                        </requirementText>
+                        <requirementText>Løsningen skal være mulig å integrere mot andre innsynsløsninger enn leverandørens egen løsning. </requirementText>
                         <priority>1</priority>
                     </requirement>
                 </requirements>
@@ -4434,103 +3104,73 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>Leverandøren skal gi en overordnet beskrivelse av tilbudt løsning for
-                                publisering av offentlige dokumenter via kommunens internettsider. Med offentlige
-                                dokumenter menes ALLE offentlige dokumenter fra forvaltningen, herunder offentlig
-                                journal, møte- og utvalgsdokumenter, dokumentasjon fra administrativt arkiv etc.
-                            </requirementText>
+                            <requirementText>Leverandøren skal gi en overordnet beskrivelse av tilbudt løsning for publisering av offentlige dokumenter via kommunens internettsider. Med offentlige dokumenter menes ALLE offentlige dokumenter fra forvaltningen, herunder offentlig journal, møte- og utvalgsdokumenter, dokumentasjon fra administrativt arkiv etc. </requirementText>
                             <priority>O (i)</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>Publiseringsløsninger skal følge Datatilsynets retningslinjer.
-                            </requirementText>
+                            <requirementText>Publiseringsløsninger skal følge Datatilsynets retningslinjer. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>Det skal være mulig å gjøre offentlig journal direkte tilgjengelig via
-                                kommunens nettsted.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å gjøre offentlig journal direkte tilgjengelig via kommunens nettsted. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>Den offentlige versjonen av et dokument skal kunne gjøres direkte
-                                tilgjengelig fra offentlig journal på internett.
-                            </requirementText>
+                            <requirementText>Den offentlige versjonen av et dokument skal kunne gjøres direkte tilgjengelig fra offentlig journal på internett. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>Det skal være valgfritt for kommunen å publisere dokumentene tilknyttet
-                                journalpostene i offentlig journal. Det skal være mulig å velge å publisere dokumentene
-                                kun for visse typer saker eller for visse deler av organisasjonen.
-                            </requirementText>
+                            <requirementText>Det skal være valgfritt for kommunen å publisere dokumentene tilknyttet journalpostene i offentlig journal. Det skal være mulig å velge å publisere dokumentene kun for visse typer saker eller for visse deler av organisasjonen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>Publisering av dokumenter skal kun skje i godkjent arkivformat.
-                            </requirementText>
+                            <requirementText>Publisering av dokumenter skal kun skje i godkjent arkivformat. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>Offentlig journal skal kunne legges ut automatisk, og til tidspunkt
-                                definert av kommunen. Det skal med andre ord ikke være nødvendig med manuelle
-                                operasjoner for å utføre selve publiseringen av offentlig journal.
-                            </requirementText>
+                            <requirementText>Offentlig journal skal kunne legges ut automatisk, og til tidspunkt definert av kommunen. Det skal med andre ord ikke være nødvendig med manuelle operasjoner for å utføre selve publiseringen av offentlig journal. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>Løsningen skal gjøre det mulig å definere en enkel godkjenningsprosess som
-                                sikrer at offentlig journal ikke publiseres før denne er godkjent av definerte brukere
-                                (eks arkivleder). Godkjenningsprosessen skal tilrettelegge for at bruker enkelt kan
-                                fjerne dokumenter som ikke skal publiseres.
-                            </requirementText>
+                            <requirementText>Løsningen skal gjøre det mulig å definere en enkel godkjenningsprosess som sikrer at offentlig journal ikke publiseres før denne er godkjent av definerte brukere (eks arkivleder). Godkjenningsprosessen skal tilrettelegge for at bruker enkelt kan fjerne dokumenter som ikke skal publiseres. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>Det skal være mulig for publikum å bestille innsyn i dokumenter som ikke er
-                                publisert. Å bestille innsyn skal kunne gjøres via en dedikert funksjon knyttet til sak
-                                og dokument.
-                            </requirementText>
+                            <requirementText>Det skal være mulig for publikum å bestille innsyn i dokumenter som ikke er publisert. Å bestille innsyn skal kunne gjøres via en dedikert funksjon knyttet til sak og dokument. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>Når det sendes anmodning om innsyn i en journalpost skal avsenders
-                                e-postadresse automatisk registreres inn i løsningen slik at ekspedering av forespurte
-                                dokumenter kan gjøres raskt og effektivt.
-                            </requirementText>
+                            <requirementText>Når det sendes anmodning om innsyn i en journalpost skal avsenders e-postadresse automatisk registreres inn i løsningen slik at ekspedering av forespurte dokumenter kan gjøres raskt og effektivt. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>Det skal være mulig for kommunen selv å definere hvilken e-postadresse
-                                melding om innsynsbegjæring skal sendes til.
-                            </requirementText>
+                            <requirementText>Det skal være mulig for kommunen selv å definere hvilken e-postadresse melding om innsynsbegjæring skal sendes til. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>Ved offentliggjøring/publisering av tillegg til sakskart som allerede er
-                                publisert, må ikke tillegg erstatte allerede publiserte dokumenter
-                            </requirementText>
+                            <requirementText>Ved offentliggjøring/publisering av tillegg til sakskart som allerede er publisert, må ikke tillegg erstatte allerede publiserte dokumenter </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -4547,19 +3187,13 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>Løsningen for publisering og presentasjon av offentlig journal på internett
-                                må være sikret på en slik måte at data i offentlig journal (spesielt personopplysninger)
-                                ikke blir registrert i eksterne søkemotorer. Leverandøren skal redegjøre for hvordan
-                                dette er ivaretatt.
-                            </requirementText>
+                            <requirementText>Løsningen for publisering og presentasjon av offentlig journal på internett må være sikret på en slik måte at data i offentlig journal (spesielt personopplysninger) ikke blir registrert i eksterne søkemotorer. Leverandøren skal redegjøre for hvordan dette er ivaretatt. </requirementText>
                             <priority>O (i)</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>Leverandøren skal beskrive hvordan løsningen for publisering av offentlig
-                                journal ivaretar kravene til universell utforming.
-                            </requirementText>
+                            <requirementText>Leverandøren skal beskrive hvordan løsningen for publisering av offentlig journal ivaretar kravene til universell utforming. </requirementText>
                             <priority>O (i)</priority>
                         </requirement>
                     </requirements>
@@ -4582,28 +3216,19 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>0</showOrder>
-                            <requirementText>Å gi kommunen mulighet til å skaffe seg informasjon om størrelse og
-                                sammensetning over tid for data lagret i løsningen.
-                            </requirementText>
+                            <requirementText>Å gi kommunen mulighet til å skaffe seg informasjon om størrelse og sammensetning over tid for data lagret i løsningen. </requirementText>
                             <priority></priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>Løsningen skal tilfredsstille alle valgfrie krav til statistikker og
-                                rapporter jf. NOARK5-standardens kapittel 10.1 (Krav 10.1.1 – 10.1.38). Leverandøren
-                                skal oppgi krav som eventuelt ikke er innfridd. Leverandøren skal også angi hvilke krav
-                                som ikke er tilfredsstilt med en standardrapport.
-                            </requirementText>
+                            <requirementText>Løsningen skal tilfredsstille alle valgfrie krav til statistikker og rapporter jf. NOARK5-standardens kapittel 10.1 (Krav 10.1.1 – 10.1.38). Leverandøren skal oppgi krav som eventuelt ikke er innfridd. Leverandøren skal også angi hvilke krav som ikke er tilfredsstilt med en standardrapport. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>Leverandøren skal redegjøre for hvordan bruker på alternative og
-                                brukervennlige måter kan fremskaffe den informasjonen som rapportene i nevnte krav har
-                                som formål å presentere.
-                            </requirementText>
+                            <requirementText>Leverandøren skal redegjøre for hvordan bruker på alternative og brukervennlige måter kan fremskaffe den informasjonen som rapportene i nevnte krav har som formål å presentere. </requirementText>
                             <priority>1 (i)</priority>
                         </requirement>
                     </requirements>
@@ -4620,56 +3245,37 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 6.5.12 (V): Krav til rapporten Offentlig journal - Rapporten skal i
-                                tillegg valgfritt kunne inneholde en eller flere av opplysningene nedenfor (så fremt de
-                                finnes i løsningen): Saksmappeinformasjon, Fra Saksmappe: AdministrativEnhet,
-                                saksansvarlig, tilgangsrestriksjon, skjermingshjemmel, Journalpostinformasjon, Fra
-                                Journalpost (sortert etter registreringsID hvis ikke annet er angitt):
-                                tilgangsrestriksjon skjermingsHjemmel administrativEnhet, saksbehandler
-                            </requirementText>
+                            <requirementText>NOARK 6.5.12 (V): Krav til rapporten Offentlig journal - Rapporten skal i tillegg valgfritt kunne inneholde en eller flere av opplysningene nedenfor (så fremt de finnes i løsningen): Saksmappeinformasjon, Fra Saksmappe: AdministrativEnhet, saksansvarlig, tilgangsrestriksjon, skjermingshjemmel, Journalpostinformasjon, Fra Journalpost (sortert etter registreringsID hvis ikke annet er angitt): tilgangsrestriksjon skjermingsHjemmel administrativEnhet, saksbehandler </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 6.5.24 (V): Krav til rapporten restanseliste - Det skal være mulig å
-                                definere rapporten slik at bestemte saksområder ikke skal tas med på restanselisten.
-                                Dette kan f. eks. være saksmapper/journalposter med bestemte ordningsverdier eller som
-                                behandles av bestemte administrative enheter.
-                            </requirementText>
+                            <requirementText>NOARK 6.5.24 (V): Krav til rapporten restanseliste - Det skal være mulig å definere rapporten slik at bestemte saksområder ikke skal tas med på restanselisten. Dette kan f. eks. være saksmapper/journalposter med bestemte ordningsverdier eller som behandles av bestemte administrative enheter. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>Løsningen skal kunne gi oversikt over saksgang: Saker avsluttet pr.
-                                saksbehandler og avdeling, Saker i arbeid pr. saksbehandler og avdeling, Milepæler,
-                                Saker som er mangelfulle, Saker som er komplette
-                            </requirementText>
+                            <requirementText>Løsningen skal kunne gi oversikt over saksgang: Saker avsluttet pr. saksbehandler og avdeling, Saker i arbeid pr. saksbehandler og avdeling, Milepæler, Saker som er mangelfulle, Saker som er komplette </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>Det skal være mulig å ta ut rapporter fra løsningen som fremskaffer de
-                                tallene som skal sendes inn i forbindelse med KOSTRA-rapporteringen. Beskriv hvordan.
-                            </requirementText>
+                            <requirementText>Det skal være mulig å ta ut rapporter fra løsningen som fremskaffer de tallene som skal sendes inn i forbindelse med KOSTRA-rapporteringen. Beskriv hvordan. </requirementText>
                             <priority>1 (i)</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>Rapporter/statistikk skal kunne fremstilles i: tekstbehandlingssystemet
-                                (Word), regneark (Excel), PDF/A, HTML
-                            </requirementText>
+                            <requirementText>Rapporter/statistikk skal kunne fremstilles i: tekstbehandlingssystemet (Word), regneark (Excel), PDF/A, HTML </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>Brukeren skal selv, for det enkelte rapportuttak, kunne bestemme hvilket
-                                format rapporten skal lages i.
-                            </requirementText>
+                            <requirementText>Brukeren skal selv, for det enkelte rapportuttak, kunne bestemme hvilket format rapporten skal lages i. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
@@ -4681,26 +3287,19 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>Rapporter som tas ut til tekstbehandlingsverktøy og regneark skal kunne
-                                redigeres av brukeren (innholdet i rapporten skal kunne behandles videre f.eks ved bruk
-                                av funksjoner og diagrammer i Excel).
-                            </requirementText>
+                            <requirementText>Rapporter som tas ut til tekstbehandlingsverktøy og regneark skal kunne redigeres av brukeren (innholdet i rapporten skal kunne behandles videre f.eks ved bruk av funksjoner og diagrammer i Excel). </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>Det skal være mulig for brukeren å lage egne rapporter. Disse rapportene
-                                skal kunne lages basert på utførte søk, og rapportene skal kunne lagres for senere bruk.
-                            </requirementText>
+                            <requirementText>Det skal være mulig for brukeren å lage egne rapporter. Disse rapportene skal kunne lages basert på utførte søk, og rapportene skal kunne lagres for senere bruk. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>Det skal være mulig for Kunden selv å definere nye «standardrapporter» som
-                                tilgjengelig gjøres for alle brukere eller for en gruppe brukere.
-                            </requirementText>
+                            <requirementText>Det skal være mulig for Kunden selv å definere nye «standardrapporter» som tilgjengelig gjøres for alle brukere eller for en gruppe brukere. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -4723,19 +3322,13 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>0</showOrder>
-                            <requirementText>Formål Å sikre ivaretakelse av at endringer i organisasjonsstruktur og
-                                administrasjon av løsningen kan håndteres smidig og uten behov for systemomarbeidelse.
-                            </requirementText>
+                            <requirementText>Formål Å sikre ivaretakelse av at endringer i organisasjonsstruktur og administrasjon av løsningen kan håndteres smidig og uten behov for systemomarbeidelse. </requirementText>
                             <priority></priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>Kunden vil ha behov for en løsning som tilbyr stor fleksibilitet med tanke
-                                på oppbygging og håndtering av strukturen for organisatoriske enheter. Kunden skal kunne
-                                strukturere arkivløsningen i henhold til egen organisasjon uten behov for at løsningen
-                                omarbeides av leverandøren
-                            </requirementText>
+                            <requirementText>Kunden vil ha behov for en løsning som tilbyr stor fleksibilitet med tanke på oppbygging og håndtering av strukturen for organisatoriske enheter. Kunden skal kunne strukturere arkivløsningen i henhold til egen organisasjon uten behov for at løsningen omarbeides av leverandøren </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -4752,192 +3345,139 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>0</showOrder>
-                            <requirementText>Formål Å sikre at kommunen kan organisere sin sak- og arkivløsning etter
-                                både en hierarkisk linjeorganisasjon og etter nettverksbaserte eller prosjektorienterte
-                                strukturer.
-                            </requirementText>
+                            <requirementText>Formål Å sikre at kommunen kan organisere sin sak- og arkivløsning etter både en hierarkisk linjeorganisasjon og etter nettverksbaserte eller prosjektorienterte strukturer. </requirementText>
                             <priority></priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 11.1.1 (V): Det skal være mulig å opprette en hierarkisk,
-                                administrativ struktur med et ubegrenset antall nivåer
-                            </requirementText>
+                            <requirementText>NOARK 11.1.1 (V): Det skal være mulig å opprette en hierarkisk, administrativ struktur med et ubegrenset antall nivåer </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 11.1.2 (V): Det skal være mulig å opprette et ubegrenset antall
-                                administrative enheter på samme nivå
-                            </requirementText>
+                            <requirementText>NOARK 11.1.2 (V): Det skal være mulig å opprette et ubegrenset antall administrative enheter på samme nivå </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 11.1.3 (V): Det skal være mulig å opprette en matrisebasert
-                                administrativ struktur, som tillater f. eks. nettverksbaserte eller prosjektorienterte
-                                organisasjonsformer
-                            </requirementText>
+                            <requirementText>NOARK 11.1.3 (V): Det skal være mulig å opprette en matrisebasert administrativ struktur, som tillater f. eks. nettverksbaserte eller prosjektorienterte organisasjonsformer </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 11.1.4 (V): Det skal være mulig å opprette en administrativ struktur
-                                som tillater en kombinasjon av hierarkiske og ikke-hierarkiske administrative strukturer
-                            </requirementText>
+                            <requirementText>NOARK 11.1.4 (V): Det skal være mulig å opprette en administrativ struktur som tillater en kombinasjon av hierarkiske og ikke-hierarkiske administrative strukturer </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 11.1.5 (V): Det skal være mulig å registrere start- og sluttdato på
-                                en hel administrativ struktur
-                            </requirementText>
+                            <requirementText>NOARK 11.1.5 (V): Det skal være mulig å registrere start- og sluttdato på en hel administrativ struktur </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 11.1.6 (V): Det skal være mulig å registrere start- og sluttdato på
-                                deler av en administrativ struktur
-                            </requirementText>
+                            <requirementText>NOARK 11.1.6 (V): Det skal være mulig å registrere start- og sluttdato på deler av en administrativ struktur </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 11.1.7 (V): Det skal være mulig å hente en eller flere avsluttede
-                                administrative strukturer
-                            </requirementText>
+                            <requirementText>NOARK 11.1.7 (V): Det skal være mulig å hente en eller flere avsluttede administrative strukturer </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 11.1.8 (V): Det skal ikke være mulig å slette en administrativ
-                                struktur
-                            </requirementText>
+                            <requirementText>NOARK 11.1.8 (V): Det skal ikke være mulig å slette en administrativ struktur </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>NOARK 11.1.9 (V): Det skal være mulig å endre den administrative
-                                strukturen.
-                            </requirementText>
+                            <requirementText>NOARK 11.1.9 (V): Det skal være mulig å endre den administrative strukturen. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>NOARK 11.1.10 (V): Det skal være mulig å føye til nye administrative
-                                enheter på et hvilket som helst nivå i strukturen
-                            </requirementText>
+                            <requirementText>NOARK 11.1.10 (V): Det skal være mulig å føye til nye administrative enheter på et hvilket som helst nivå i strukturen </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>NOARK 11.1.11 (V): Det skal være mulig å endre opplysninger om en bestemt
-                                administrativ enhet. Endringene skal logges.
-                            </requirementText>
+                            <requirementText>NOARK 11.1.11 (V): Det skal være mulig å endre opplysninger om en bestemt administrativ enhet. Endringene skal logges. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>NOARK 11.1.12 (V): Det skal være mulig å endre opplysninger om et utvalg
-                                administrative enheter. Endringene skal logges.
-                            </requirementText>
+                            <requirementText>NOARK 11.1.12 (V): Det skal være mulig å endre opplysninger om et utvalg administrative enheter. Endringene skal logges. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>13</showOrder>
-                            <requirementText>NOARK 11.1.13 (V): Det skal være mulig å registrere følgende metadata for
-                                administrativ enhet: 1) Enhetens nåværende, fulle navn, 2) Enhetens kortnavn, 3) Dato
-                                for når enheten ble opprettet, 4) Dato for når enheten utgår, 5) Alle tidligere navn på
-                                enheten, 6) Alle tidligere kortnavn på enheten, 7) Adresse til administrativ enhet,
-                                inkl. evt. e-post
-                            </requirementText>
+                            <requirementText>NOARK 11.1.13 (V): Det skal være mulig å registrere følgende metadata for administrativ enhet: 1) Enhetens nåværende, fulle navn, 2) Enhetens kortnavn, 3) Dato for når enheten ble opprettet, 4) Dato for når enheten utgår, 5) Alle tidligere navn på enheten, 6) Alle tidligere kortnavn på enheten, 7) Adresse til administrativ enhet, inkl. evt. e-post </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>14</showOrder>
-                            <requirementText>NOARK 11.1.14 (V): Det skal være mulig å endre opplysninger om en
-                                administrativ enhets navn
-                            </requirementText>
+                            <requirementText>NOARK 11.1.14 (V): Det skal være mulig å endre opplysninger om en administrativ enhets navn </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>15</showOrder>
-                            <requirementText>NOARK 11.1.15 (V): Det skal ikke være mulig å slette en administrativ
-                                enhets navn.
-                            </requirementText>
+                            <requirementText>NOARK 11.1.15 (V): Det skal ikke være mulig å slette en administrativ enhets navn. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>16</showOrder>
-                            <requirementText>NOARK 11.1.16 (V): Det skal finnes funksjoner for å bevare de(t)
-                                opprinnelige navnet / navnene på administrative enheter ved navneendringer
-                            </requirementText>
+                            <requirementText>NOARK 11.1.16 (V): Det skal finnes funksjoner for å bevare de(t) opprinnelige navnet / navnene på administrative enheter ved navneendringer </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>17</showOrder>
-                            <requirementText>NOARK 11.1.17 (V): Det skal være mulig å sette start- og sluttdato på en
-                                administrativ enhet
-                            </requirementText>
+                            <requirementText>NOARK 11.1.17 (V): Det skal være mulig å sette start- og sluttdato på en administrativ enhet </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>18</showOrder>
-                            <requirementText>NOARK 11.1.18 (V): Det skal ikke være mulig å knytte nye mapper eller
-                                registreringer til en avsluttet administrativ enhet
-                            </requirementText>
+                            <requirementText>NOARK 11.1.18 (V): Det skal ikke være mulig å knytte nye mapper eller registreringer til en avsluttet administrativ enhet </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>19</showOrder>
-                            <requirementText>NOARK 11.1.19 (V): Det skal ikke være mulig å slette en administrativ enhet
-                                som har tilknyttet en mappe eller en registrering
-                            </requirementText>
+                            <requirementText>NOARK 11.1.19 (V): Det skal ikke være mulig å slette en administrativ enhet som har tilknyttet en mappe eller en registrering </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>20</showOrder>
-                            <requirementText>NOARK 11.1.20 (V): Det skal være mulig å parameterstyre om et søk på
-                                administrativ enhet også skal omfatte samme enhet under tidligere navn
-                            </requirementText>
+                            <requirementText>NOARK 11.1.20 (V): Det skal være mulig å parameterstyre om et søk på administrativ enhet også skal omfatte samme enhet under tidligere navn </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>21</showOrder>
-                            <requirementText>NOARK 11.1.21 (V): Ved søk på en administrativ enhet, skal søket automatisk
-                                også omfatte eventuelle underliggende enheter. Dette skal kunne overstyres.
-                            </requirementText>
+                            <requirementText>NOARK 11.1.21 (V): Ved søk på en administrativ enhet, skal søket automatisk også omfatte eventuelle underliggende enheter. Dette skal kunne overstyres. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>22</showOrder>
-                            <requirementText>NOARK 11.1.22 (V): Den administrative strukturen skal være helt uavhengig
-                                av arkivstrukturen. Et arkiv eller en arkivdel skal derfor kunne dekke: 1) en hel
-                                administrativ enhet, 2) deler av en administrativ enhet, 3) flere administrative
-                                enheter, 4) andre typer administrative strukturer enn de hierarkiske
-                            </requirementText>
+                            <requirementText>NOARK 11.1.22 (V): Den administrative strukturen skal være helt uavhengig av arkivstrukturen. Et arkiv eller en arkivdel skal derfor kunne dekke: 1) en hel administrativ enhet, 2) deler av en administrativ enhet, 3) flere administrative enheter, 4) andre typer administrative strukturer enn de hierarkiske </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -4954,115 +3494,85 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 11.2.1 (V): Det skal være mulig å opprette et vilkårlig antall
-                                brukere
-                            </requirementText>
+                            <requirementText>NOARK 11.2.1 (V): Det skal være mulig å opprette et vilkårlig antall brukere </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 11.2.2 (V): Bruker skal bare kunne benytte de funksjoner og den
-                                informasjon som vedkommende er autorisert for
-                            </requirementText>
+                            <requirementText>NOARK 11.2.2 (V): Bruker skal bare kunne benytte de funksjoner og den informasjon som vedkommende er autorisert for </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 11.2.3 (V): Det skal være mulig å bestemme aten person kan foreta
-                                registrering på vegne av en annen, og med dennes rettigheter
-                            </requirementText>
+                            <requirementText>NOARK 11.2.3 (V): Det skal være mulig å bestemme aten person kan foreta registrering på vegne av en annen, og med dennes rettigheter </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 11.2.4 (V): Det skal være mulig å registrere følgende metadata for
-                                bruker: 1) Brukerens nåværende, fulle navn, 2) Brukerens initialer, 3) Dato for når
-                                bruker ble opprettet, 4) Dato for når bruker utgår, 5) Alle tidligere navn, 6) Alle
-                                tidligere initialer
-                            </requirementText>
+                            <requirementText>NOARK 11.2.4 (V): Det skal være mulig å registrere følgende metadata for bruker: 1) Brukerens nåværende, fulle navn, 2) Brukerens initialer, 3) Dato for når bruker ble opprettet, 4) Dato for når bruker utgår, 5) Alle tidligere navn, 6) Alle tidligere initialer </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 11.2.5 (V): Det skal være mulig å endre opplysninger om et utvalg
-                                brukere. Endringene skal logges.
-                            </requirementText>
+                            <requirementText>NOARK 11.2.5 (V): Det skal være mulig å endre opplysninger om et utvalg brukere. Endringene skal logges. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 11.2.6 (V): Det skal være mulig å endre opplysninger om en brukers
-                                navn og initialer.
-                            </requirementText>
+                            <requirementText>NOARK 11.2.6 (V): Det skal være mulig å endre opplysninger om en brukers navn og initialer. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 11.2.7 (V): Det skal ikke være mulig å slette en brukers navn.
-                            </requirementText>
+                            <requirementText>NOARK 11.2.7 (V): Det skal ikke være mulig å slette en brukers navn. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 11.2.8 (V): Det skal finnes funksjoner for å bevare de(t)
-                                opprinnelige navnet / navnene på brukeren ved navneendringer
-                            </requirementText>
+                            <requirementText>NOARK 11.2.8 (V): Det skal finnes funksjoner for å bevare de(t) opprinnelige navnet / navnene på brukeren ved navneendringer </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>NOARK 11.2.9 (V): Alle navn og initialer skal kunne bevares i løsningen
-                                sammen med opplysninger om tidsrom for bruk
-                            </requirementText>
+                            <requirementText>NOARK 11.2.9 (V): Alle navn og initialer skal kunne bevares i løsningen sammen med opplysninger om tidsrom for bruk </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>NOARK 11.2.10 (V): Løsningen skal holde rede på hvilke navn og initialer
-                                som tilhører samme person
-                            </requirementText>
+                            <requirementText>NOARK 11.2.10 (V): Løsningen skal holde rede på hvilke navn og initialer som tilhører samme person </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>NOARK 11.2.11 (V): Det skal være mulig å parameterstyre om et søk på bruker
-                                også skal omfatte samme bruker under tidligere navn
-                            </requirementText>
+                            <requirementText>NOARK 11.2.11 (V): Det skal være mulig å parameterstyre om et søk på bruker også skal omfatte samme bruker under tidligere navn </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>NOARK 11.2.12 (V): Det skal ikke være mulig å knytte nye mapper eller
-                                registreringer til en avsluttet (utgått) bruker
-                            </requirementText>
+                            <requirementText>NOARK 11.2.12 (V): Det skal ikke være mulig å knytte nye mapper eller registreringer til en avsluttet (utgått) bruker </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>13</showOrder>
-                            <requirementText>NOARK 11.2.13 (V): Det skal ikke være mulig å slette en bruker som har
-                                tilknyttet en mappe eller en registrering
-                            </requirementText>
+                            <requirementText>NOARK 11.2.13 (V): Det skal ikke være mulig å slette en bruker som har tilknyttet en mappe eller en registrering </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>14</showOrder>
-                            <requirementText>NOARK 11.2.14 (V): Det skal være mulig å registrere adresse og andre
-                                kontoradministrative eller private data knyttet til en bruker, for eksempel telefon,
-                                faks, e-post, kontor, hjemmeadresse, mv.
-                            </requirementText>
+                            <requirementText>NOARK 11.2.14 (V): Det skal være mulig å registrere adresse og andre kontoradministrative eller private data knyttet til en bruker, for eksempel telefon, faks, e-post, kontor, hjemmeadresse, mv. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
@@ -5074,15 +3584,13 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>16</showOrder>
-                            <requirementText>NOARK 11.2.16 (V): Det skal være mulig å slette en adresse
-                            </requirementText>
+                            <requirementText>NOARK 11.2.16 (V): Det skal være mulig å slette en adresse </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>17</showOrder>
-                            <requirementText>NOARK 11.2.17 (V): Det skal være mulig å hente fram en adresse
-                            </requirementText>
+                            <requirementText>NOARK 11.2.17 (V): Det skal være mulig å hente fram en adresse </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -5105,27 +3613,19 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>Leverandøren skal gi en overordnet beskrivelse av hvordan sikkerheten (slik
-                                den defineres i innledningen til kap 7.1) i løsningen ivaretas.
-                            </requirementText>
+                            <requirementText>Leverandøren skal gi en overordnet beskrivelse av hvordan sikkerheten (slik den defineres i innledningen til kap 7.1) i løsningen ivaretas. </requirementText>
                             <priority>O (i)</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>Løsningen skal ivareta de krav til sikkerhet som er satt i henhold til
-                                lover og forskrifter, herunder Datatilsynets krav til personsikkerhet. Leverandøren må
-                                opplyse om hvilke krav som stilles til Kunden, for at dette skal ivaretas.
-                            </requirementText>
+                            <requirementText>Løsningen skal ivareta de krav til sikkerhet som er satt i henhold til lover og forskrifter, herunder Datatilsynets krav til personsikkerhet. Leverandøren må opplyse om hvilke krav som stilles til Kunden, for at dette skal ivaretas. </requirementText>
                             <priority>O (i)</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>Løsningen skal være sikret på en slik måte at ingen kan få tilgang til
-                                informasjon de ikke er autorisert for. Dette gjelder uavhengig av om de benytter
-                                Løsningen eller et annet verktøy.
-                            </requirementText>
+                            <requirementText>Løsningen skal være sikret på en slik måte at ingen kan få tilgang til informasjon de ikke er autorisert for. Dette gjelder uavhengig av om de benytter Løsningen eller et annet verktøy. </requirementText>
                             <priority>O</priority>
                         </requirement>
                     </requirements>
@@ -5142,78 +3642,55 @@
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>Løsningen skal tilfredsstille alle valgfrie krav til roller og tilknyttede
-                                rettigheter jf. NOARK5-standardens kapittel 11.2.2 (Krav 11.2.18 – 11.2.32).
-                                Leverandøren skal oppgi krav som eventuelt ikke er innfridd og redegjøre for
-                                konsekvensene av dette.
-                            </requirementText>
+                            <requirementText>Løsningen skal tilfredsstille alle valgfrie krav til roller og tilknyttede rettigheter jf. NOARK5-standardens kapittel 11.2.2 (Krav 11.2.18 – 11.2.32). Leverandøren skal oppgi krav som eventuelt ikke er innfridd og redegjøre for konsekvensene av dette. </requirementText>
                             <priority>1 (i)</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>Løsningen skal tilfredsstille alle valgfrie krav til brukers relasjon til
-                                rolle, administrativ enhet og arkivdel jf. NOARK5-standardens kapittel 11.2.3 (Krav
-                                11.2.33 – 11.2.46). Leverandøren skal oppgi krav som eventuelt ikke er innfridd og
-                                redegjøre for konsekvensene av dette.
-                            </requirementText>
+                            <requirementText>Løsningen skal tilfredsstille alle valgfrie krav til brukers relasjon til rolle, administrativ enhet og arkivdel jf. NOARK5-standardens kapittel 11.2.3 (Krav 11.2.33 – 11.2.46). Leverandøren skal oppgi krav som eventuelt ikke er innfridd og redegjøre for konsekvensene av dette. </requirementText>
                             <priority>1 (i)</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>Det må være mulig å gjøre lokale tilpasninger, slik at man kan legge inn de
-                                rollene man har behov for i systemet.
-                            </requirementText>
+                            <requirementText>Det må være mulig å gjøre lokale tilpasninger, slik at man kan legge inn de rollene man har behov for i systemet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>Rettigheter og tilganger må være lett å administrere. Fortrinnvis basert på
-                                gruppemedlemskap.
-                            </requirementText>
+                            <requirementText>Rettigheter og tilganger må være lett å administrere. Fortrinnvis basert på gruppemedlemskap. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>Løsningen må gi støtte for differensiering av tilganger og rettigheter;
-                                herunder å gi brukerne ulike tilganger til ulike funksjoner i systemet. Tilgangsnivåene
-                                må baseres på roller og grupper.
-                            </requirementText>
+                            <requirementText>Løsningen må gi støtte for differensiering av tilganger og rettigheter; herunder å gi brukerne ulike tilganger til ulike funksjoner i systemet. Tilgangsnivåene må baseres på roller og grupper. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>Tilgangskontrollsystemet må ha en logisk oppbygging, det må være lett å
-                                lære, lett å bruke og lett å foreta endringer samtidig som sikkerheten ivaretas.
-                            </requirementText>
+                            <requirementText>Tilgangskontrollsystemet må ha en logisk oppbygging, det må være lett å lære, lett å bruke og lett å foreta endringer samtidig som sikkerheten ivaretas. </requirementText>
                             <priority>2</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>Det må være enkelt og raskt å endre tilganger og håndtere
-                                systemadministrasjon uten å måtte tilkalle leverandøren
-                            </requirementText>
+                            <requirementText>Det må være enkelt og raskt å endre tilganger og håndtere systemadministrasjon uten å måtte tilkalle leverandøren </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>Leverandøren skal beskrive hvordan sikkerheten ivaretas i
-                                tilgangskontrollsystemet
-                            </requirementText>
+                            <requirementText>Leverandøren skal beskrive hvordan sikkerheten ivaretas i tilgangskontrollsystemet </requirementText>
                             <priority>O (i)</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>Leverandøren skal beskrive hvordan sikkerheten ivaretas ved ekstern
-                                pålogging
-                            </requirementText>
+                            <requirementText>Leverandøren skal beskrive hvordan sikkerheten ivaretas ved ekstern pålogging </requirementText>
                             <priority>O (i)</priority>
                         </requirement>
                     </requirements>
@@ -5230,181 +3707,127 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 12.2.12 (V): Det skal kunne angis krav til passordets styrke
-                                (kompleksitet, lengde, varighet etc.)
-                            </requirementText>
+                            <requirementText>NOARK 12.2.12 (V): Det skal kunne angis krav til passordets styrke (kompleksitet, lengde, varighet etc.) </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 12.2.13 (V): Det skal kunne brukes andre og sterkere
-                                autentiseringsmåter som alternativ til passord
-                            </requirementText>
+                            <requirementText>NOARK 12.2.13 (V): Det skal kunne brukes andre og sterkere autentiseringsmåter som alternativ til passord </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 12.2.15 (V): Dersom en svak autentisering anses tilstrekkelig for å
-                                bruke Noark 5-løsningen, skal det likevel legges opp til at påloggingen aksepteres også
-                                for en bruker som er sterkere autentisert enn det som egentlig er nødvendig
-                            </requirementText>
+                            <requirementText>NOARK 12.2.15 (V): Dersom en svak autentisering anses tilstrekkelig for å bruke Noark 5-løsningen, skal det likevel legges opp til at påloggingen aksepteres også for en bruker som er sterkere autentisert enn det som egentlig er nødvendig </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 12.2.21 (V): Et «need to protect» grunnprinsipp kan velges for
-                                lesetilganger i en eller flere eksterne løsninger
-                            </requirementText>
+                            <requirementText>NOARK 12.2.21 (V): Et «need to protect» grunnprinsipp kan velges for lesetilganger i en eller flere eksterne løsninger </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 12.2.22 (V): Ulike kombinasjoner av funksjonelle krav som stilles til
-                                brukerens autorisasjon skal kunne settes sammen til forskjellige funksjonelle roller,
-                                som uttrykker typiske stillingskategorier eller oppgaveporteføljer i virksomheten
-                            </requirementText>
+                            <requirementText>NOARK 12.2.22 (V): Ulike kombinasjoner av funksjonelle krav som stilles til brukerens autorisasjon skal kunne settes sammen til forskjellige funksjonelle roller, som uttrykker typiske stillingskategorier eller oppgaveporteføljer i virksomheten </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 12.2.23 (V): For hver funksjonelle rolle skal det være mulig å
-                                definere et regelsett for prosessrelaterte rettigheter.
-                            </requirementText>
+                            <requirementText>NOARK 12.2.23 (V): For hver funksjonelle rolle skal det være mulig å definere et regelsett for prosessrelaterte rettigheter. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>7</showOrder>
-                            <requirementText>NOARK 12.2.24 (V): En bruker skal kunne ha flere ulike roller
-                            </requirementText>
+                            <requirementText>NOARK 12.2.24 (V): En bruker skal kunne ha flere ulike roller </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>8</showOrder>
-                            <requirementText>NOARK 12.2.34 (V): Tilgangene for en bruker i en rolle skal kunne avgrenses
-                                innen angitt element i arkivstrukturen, ett av følgende: 1) Hele Noark 5-løsningen, 2)
-                                Logisk arkiv, 3) Arkivdel, 4) Mappe, 5) Registrering
-                            </requirementText>
+                            <requirementText>NOARK 12.2.34 (V): Tilgangene for en bruker i en rolle skal kunne avgrenses innen angitt element i arkivstrukturen, ett av følgende: 1) Hele Noark 5-løsningen, 2) Logisk arkiv, 3) Arkivdel, 4) Mappe, 5) Registrering </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>9</showOrder>
-                            <requirementText>NOARK 12.2.35 (V): Tilgangene for en bruker i en rolle skal kunne avgrenses
-                                innen angitte organisatoriske grenser, en av følgende: 1) Hele virksomheten, 2) Egen
-                                administrativ enhet uten underliggende enheter, 3) Egen administrativ enhet og
-                                underliggende enheter, 4) Navngitt annen administrativ enhet
-                            </requirementText>
+                            <requirementText>NOARK 12.2.35 (V): Tilgangene for en bruker i en rolle skal kunne avgrenses innen angitte organisatoriske grenser, en av følgende: 1) Hele virksomheten, 2) Egen administrativ enhet uten underliggende enheter, 3) Egen administrativ enhet og underliggende enheter, 4) Navngitt annen administrativ enhet </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>10</showOrder>
-                            <requirementText>NOARK 12.2.36 (V): Løsningen skal ha som et konfigurerbart valg en mulighet
-                                for å angi at den som er registrert som saksbehandler for en registrering automatisk
-                                også har redigeringsrettigheter til den
-                            </requirementText>
+                            <requirementText>NOARK 12.2.36 (V): Løsningen skal ha som et konfigurerbart valg en mulighet for å angi at den som er registrert som saksbehandler for en registrering automatisk også har redigeringsrettigheter til den </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>11</showOrder>
-                            <requirementText>NOARK 12.2.38 (V): Tilgangene for en bruker i en rolle skal kunne avgrenses
-                                til visse saksområder, og (eller sakstyper) og/eller bare til saker produsert av et
-                                konkret angitt fagsystem
-                            </requirementText>
+                            <requirementText>NOARK 12.2.38 (V): Tilgangene for en bruker i en rolle skal kunne avgrenses til visse saksområder, og (eller sakstyper) og/eller bare til saker produsert av et konkret angitt fagsystem </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>12</showOrder>
-                            <requirementText>NOARK 12.2.43 (V): Innenfor hver av rollene som en bruker har, skal det
-                                kunne defineres en tilgangsprofil som utgjøres av rollens funksjonelle rettigheter i
-                                kombinasjon med nedslagsfeltet for rollen
-                            </requirementText>
+                            <requirementText>NOARK 12.2.43 (V): Innenfor hver av rollene som en bruker har, skal det kunne defineres en tilgangsprofil som utgjøres av rollens funksjonelle rettigheter i kombinasjon med nedslagsfeltet for rollen </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>13</showOrder>
-                            <requirementText>NOARK 12.2.44 (V): Dersom en påloggingsidentifikator har flere forskjellige
-                                tilgangsprofiler, skal vedkommende kunne velge blant de tilgangsprofilene som er
-                                definert for vedkommende.
-                            </requirementText>
+                            <requirementText>NOARK 12.2.44 (V): Dersom en påloggingsidentifikator har flere forskjellige tilgangsprofiler, skal vedkommende kunne velge blant de tilgangsprofilene som er definert for vedkommende. </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>14</showOrder>
-                            <requirementText>NOARK 12.2.45 (V): Det skal kunne byttes mellom tilgangsprofiler på en måte
-                                som oppleves som enkel for brukeren
-                            </requirementText>
+                            <requirementText>NOARK 12.2.45 (V): Det skal kunne byttes mellom tilgangsprofiler på en måte som oppleves som enkel for brukeren </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>15</showOrder>
-                            <requirementText>NOARK 12.2.46 (V): En av brukerens tilgangsprofiler skal kunne angis som
-                                standardprofil, som tilordnes ved pålogging hvis ikke annet angis særskilt
-                            </requirementText>
+                            <requirementText>NOARK 12.2.46 (V): En av brukerens tilgangsprofiler skal kunne angis som standardprofil, som tilordnes ved pålogging hvis ikke annet angis særskilt </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>16</showOrder>
-                            <requirementText>NOARK 12.2.47 (V): Det skal være mulig å definere tilgangsprofiler som er
-                                slik at samme bruker kan ha definert forskjellige nedslagsfelter for en eller flere av
-                                sine roller
-                            </requirementText>
+                            <requirementText>NOARK 12.2.47 (V): Det skal være mulig å definere tilgangsprofiler som er slik at samme bruker kan ha definert forskjellige nedslagsfelter for en eller flere av sine roller </requirementText>
                             <priority>O</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>17</showOrder>
-                            <requirementText>NOARK 12.2.63 (V): For en gitt, aktiv påloggingsidentifikator skal det være
-                                mulig å vise eller skrive ut en oversikt over hvilke rettigheter og fullmakter
-                                vedkommende har i Noark 5-løsningen
-                            </requirementText>
+                            <requirementText>NOARK 12.2.63 (V): For en gitt, aktiv påloggingsidentifikator skal det være mulig å vise eller skrive ut en oversikt over hvilke rettigheter og fullmakter vedkommende har i Noark 5-løsningen </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>18</showOrder>
-                            <requirementText>NOARK 12.2.64 (V): Det skal være mulig å vise eller skrive ut oversikt over
-                                hvilke fullmakter en bestemt rolle eller tilgangsprofil har i løsningen
-                            </requirementText>
+                            <requirementText>NOARK 12.2.64 (V): Det skal være mulig å vise eller skrive ut oversikt over hvilke fullmakter en bestemt rolle eller tilgangsprofil har i løsningen </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>19</showOrder>
-                            <requirementText>NOARK 12.2.65 (V): For et gitt objekt i Noark 5-løsningen skal det være
-                                mulig å vise eller skrive ut hvilke brukere som har de ulike typene funksjonelle
-                                rettigheter til dette objektet
-                            </requirementText>
+                            <requirementText>NOARK 12.2.65 (V): For et gitt objekt i Noark 5-løsningen skal det være mulig å vise eller skrive ut hvilke brukere som har de ulike typene funksjonelle rettigheter til dette objektet </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>20</showOrder>
-                            <requirementText>Det skal tilrettelegges for «single sign-on» slik at brukerens sentrale
-                                passord benyttes, og brukeren slipper å logge seg inn i sak- og arkivløsningen (med
-                                passord) etter pålogging mot Organisasjonens nettverk.
-                            </requirementText>
+                            <requirementText>Det skal tilrettelegges for «single sign-on» slik at brukerens sentrale passord benyttes, og brukeren slipper å logge seg inn i sak- og arkivløsningen (med passord) etter pålogging mot Organisasjonens nettverk. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>false</noarkRequirement>
                             <showOrder>21</showOrder>
-                            <requirementText>Det skal kunne tilrettelegges for integrasjon mot Kundens Active
-                                Directory.
-                            </requirementText>
+                            <requirementText>Det skal kunne tilrettelegges for integrasjon mot Kundens Active Directory. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -5421,52 +3844,37 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 12.2.52 (V): En bruker skal kunne registreres som fast stedfortreder
-                                for en annen bruker
-                            </requirementText>
+                            <requirementText>NOARK 12.2.52 (V): En bruker skal kunne registreres som fast stedfortreder for en annen bruker </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 12.2.53 (V): En bruker skal kunne registreres som tidsavgrenset
-                                stedfortreder for en annen bruker, med gyldighet fra dato til dato
-                            </requirementText>
+                            <requirementText>NOARK 12.2.53 (V): En bruker skal kunne registreres som tidsavgrenset stedfortreder for en annen bruker, med gyldighet fra dato til dato </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 12.2.56 (V): Ved pålogging, eller i andre brukerdialoger der en
-                                påloggingsidentifikator kan velge mellom tilgjengelige roller eller tilgangsprofiler,
-                                skal det også listes opp hvilke brukere vedkommende har anledning til å være
-                                stedfortreder for, og velge å autorisere seg som en av disse
-                            </requirementText>
+                            <requirementText>NOARK 12.2.56 (V): Ved pålogging, eller i andre brukerdialoger der en påloggingsidentifikator kan velge mellom tilgjengelige roller eller tilgangsprofiler, skal det også listes opp hvilke brukere vedkommende har anledning til å være stedfortreder for, og velge å autorisere seg som en av disse </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 12.2.57 (V): Stedfortrederen skal i utgangspunktet ha samme
-                                autorisasjon som den vedkommende er stedfortreder for
-                            </requirementText>
+                            <requirementText>NOARK 12.2.57 (V): Stedfortrederen skal i utgangspunktet ha samme autorisasjon som den vedkommende er stedfortreder for </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 12.2.58 (V): Dersom den man er stedfortreder for har flere roller,
-                                skal det være mulig å avgrense stedfortrederens tilganger til en mindre andel av disse
-                                rollene
-                            </requirementText>
+                            <requirementText>NOARK 12.2.58 (V): Dersom den man er stedfortreder for har flere roller, skal det være mulig å avgrense stedfortrederens tilganger til en mindre andel av disse rollene </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 12.2.59 (V): For en eller flere angitte roller skal det være mulig å
-                                definere at den bestemte rollen ikke skal være delegerbar til stedfortreder.
-                            </requirementText>
+                            <requirementText>NOARK 12.2.59 (V): For en eller flere angitte roller skal det være mulig å definere at den bestemte rollen ikke skal være delegerbar til stedfortreder. </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -5483,39 +3891,25 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 12.2.5 (V): Eksterne brukere, for eksempel journalister, borgere i
-                                alminnelighet, eller borgere og andre virksomheter i egenskap av parter i en sak, skal
-                                kunne gis tilgang til særskilt tilrettelagt ekstern løsning, med funksjonalitet
-                                begrenset til det aktuelle formålet.
-                            </requirementText>
+                            <requirementText>NOARK 12.2.5 (V): Eksterne brukere, for eksempel journalister, borgere i alminnelighet, eller borgere og andre virksomheter i egenskap av parter i en sak, skal kunne gis tilgang til særskilt tilrettelagt ekstern løsning, med funksjonalitet begrenset til det aktuelle formålet. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 12.2.7 (V): Eksterne brukere kan autentiseres via ekstern,
-                                tredjeparts påloggingstjeneste. (Kravet er primært ment å dekke den offentlige
-                                sikkerhetsportalen til tjenesten Minside.no, men kan også få anvendelse for andre
-                                påloggingstjenester)
-                            </requirementText>
+                            <requirementText>NOARK 12.2.7 (V): Eksterne brukere kan autentiseres via ekstern, tredjeparts påloggingstjeneste. (Kravet er primært ment å dekke den offentlige sikkerhetsportalen til tjenesten Minside.no, men kan også få anvendelse for andre påloggingstjenester) </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 12.2.9 (V): Ikke-identifiserte eller svakt autentiserte eksterne
-                                brukere skal kunne gis tilgang til publiseringsuttrekk som er atskilt fra Noark 5
-                                kjernen, for å gi innsyn i saker og dokumenter
-                            </requirementText>
+                            <requirementText>NOARK 12.2.9 (V): Ikke-identifiserte eller svakt autentiserte eksterne brukere skal kunne gis tilgang til publiseringsuttrekk som er atskilt fra Noark 5 kjernen, for å gi innsyn i saker og dokumenter </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 12.3.7 (V): Dersom en person er autentisert som ekstern bruker, skal
-                                vedkommende selv kunne hente ut de opplysninger vedkommende har rett til innsyn i som
-                                part eller som registrert person gjennom tilrettelagt fagsystem eller innsynsløsning
-                            </requirementText>
+                            <requirementText>NOARK 12.3.7 (V): Dersom en person er autentisert som ekstern bruker, skal vedkommende selv kunne hente ut de opplysninger vedkommende har rett til innsyn i som part eller som registrert person gjennom tilrettelagt fagsystem eller innsynsløsning </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -5532,21 +3926,13 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 12.2.16 (V): En påloggingsidentifikator («brukerident») som ikke
-                                lenger skal ha tilgang til løsningen skal kunne settes til status «passiv», som ikke gir
-                                muligheter for å logge på
-                            </requirementText>
+                            <requirementText>NOARK 12.2.16 (V): En påloggingsidentifikator («brukerident») som ikke lenger skal ha tilgang til løsningen skal kunne settes til status «passiv», som ikke gir muligheter for å logge på </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 12.2.18 (V): Brukerens «fulle navn», og eventuelle initialer som
-                                brukes til å identifisere brukeren som saksbehandler i dokumenter og skjermbilder, skal
-                                kunne endres for en gitt brukerident. Endring av navn og initialer for en brukerident er
-                                bare aktuelt dersom samme person skifter navn, og ikke for å tildele en tidligere brukt
-                                identifikator til en annen person
-                            </requirementText>
+                            <requirementText>NOARK 12.2.18 (V): Brukerens «fulle navn», og eventuelle initialer som brukes til å identifisere brukeren som saksbehandler i dokumenter og skjermbilder, skal kunne endres for en gitt brukerident. Endring av navn og initialer for en brukerident er bare aktuelt dersom samme person skifter navn, og ikke for å tildele en tidligere brukt identifikator til en annen person </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -5563,55 +3949,37 @@
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>1</showOrder>
-                            <requirementText>NOARK 12.4.1 (V): Hvis et inngående kryptert dokument er signert
-                                elektronisk av en annen enn den som er oppgitt som avsender, skal Noark 5-løsningen
-                                varsle om dette
-                            </requirementText>
+                            <requirementText>NOARK 12.4.1 (V): Hvis et inngående kryptert dokument er signert elektronisk av en annen enn den som er oppgitt som avsender, skal Noark 5-løsningen varsle om dette </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>2</showOrder>
-                            <requirementText>NOARK 12.4.2 (V): Hvis dokument som nevnt ovenfor er sendt med et
-                                utvekslingsformat som normalt fører til at det behandles automatisk, skal det overføres
-                                til manuell behandling
-                            </requirementText>
+                            <requirementText>NOARK 12.4.2 (V): Hvis dokument som nevnt ovenfor er sendt med et utvekslingsformat som normalt fører til at det behandles automatisk, skal det overføres til manuell behandling </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>3</showOrder>
-                            <requirementText>NOARK 12.4.3 (V): Når organet sender ut et elektronisk dokument som er svar
-                                på et inngående elektronisk dokument, skal dokumentet sendes ut med minst like høyt
-                                sikkerhetsnivå som det inngående dokumentet hadde.
-                            </requirementText>
+                            <requirementText>NOARK 12.4.3 (V): Når organet sender ut et elektronisk dokument som er svar på et inngående elektronisk dokument, skal dokumentet sendes ut med minst like høyt sikkerhetsnivå som det inngående dokumentet hadde. </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>4</showOrder>
-                            <requirementText>NOARK 12.4.4 (V): Dersom mottatte dokumenter skal lagres i kryptert form,
-                                skal de først dekrypteres og så krypteres på nytt med signaturer som organet selv har
-                                kontroll over, slik at man ikke er avhengig av avsenders offentlige nøkkel ved fremtidig
-                                bruk av dokumentet
-                            </requirementText>
+                            <requirementText>NOARK 12.4.4 (V): Dersom mottatte dokumenter skal lagres i kryptert form, skal de først dekrypteres og så krypteres på nytt med signaturer som organet selv har kontroll over, slik at man ikke er avhengig av avsenders offentlige nøkkel ved fremtidig bruk av dokumentet </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>5</showOrder>
-                            <requirementText>NOARK 12.4.5 (V): Ved avlevering av elektronisk arkiv til arkivinstitusjon
-                                skal fortrinnsvis alle krypterte dokumenter dekrypteres
-                            </requirementText>
+                            <requirementText>NOARK 12.4.5 (V): Ved avlevering av elektronisk arkiv til arkivinstitusjon skal fortrinnsvis alle krypterte dokumenter dekrypteres </requirementText>
                             <priority>1</priority>
                         </requirement>
                         <requirement>
                             <noarkRequirement>true</noarkRequirement>
                             <showOrder>6</showOrder>
-                            <requirementText>NOARK 12.4.6 (V): Dersom krypterte dokumenter skal forbli krypterte ved
-                                lagring i arkivinstitusjon, bør de først dekrypteres og så krypteres på nytt med
-                                signaturer som arkivinstitusjonen har kontroll over
-                            </requirementText>
+                            <requirementText>NOARK 12.4.6 (V): Dersom krypterte dokumenter skal forbli krypterte ved lagring i arkivinstitusjon, bør de først dekrypteres og så krypteres på nytt med signaturer som arkivinstitusjonen har kontroll over </requirementText>
                             <priority>1</priority>
                         </requirement>
                     </requirements>
@@ -5629,170 +3997,97 @@
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>NOARK 13.2.1 (V): Løsningen skal ha funksjoner som automatisk registrerer og
-                            lagrer opplysninger om definerte hendelser som har skjedd med dokumenter og metadata i
-                            løsningen.
-                        </requirementText>
+                        <requirementText>NOARK 13.2.1 (V): Løsningen skal ha funksjoner som automatisk registrerer og lagrer opplysninger om definerte hendelser som har skjedd med dokumenter og metadata i løsningen. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>NOARK 13.2.2 (V): Løsningen skal ha et register som spesifiserer hvilke
-                            hendelser (definerte regler) som skal utløse registrering av sporingsinformasjon
-                        </requirementText>
+                        <requirementText>NOARK 13.2.2 (V): Løsningen skal ha et register som spesifiserer hvilke hendelser (definerte regler) som skal utløse registrering av sporingsinformasjon </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>NOARK 13.2.4 (V): Forskjellige typer hendelser skal kunne logges til
-                            forskjellige eksterne filer eller databasetabeller. (Visse typer logger, for eksempel for
-                            revisjon av tilgangskontroller, må kunne slettes etter en avgrenset tid. Andre typer logger
-                            skal tas vare på lenge. Logger som skal slettes og logger som skal tas vare på skal holdes
-                            fra hverandre)
-                        </requirementText>
+                        <requirementText>NOARK 13.2.4 (V): Forskjellige typer hendelser skal kunne logges til forskjellige eksterne filer eller databasetabeller. (Visse typer logger, for eksempel for revisjon av tilgangskontroller, må kunne slettes etter en avgrenset tid. Andre typer logger skal tas vare på lenge. Logger som skal slettes og logger som skal tas vare på skal holdes fra hverandre) </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>NOARK 13.2.6 (V): Loggingen skal være konfigurerbar. Som et minimum skal
-                            anbefalte loggingsregler kunne settes av eller på av system- eller arkivadministrator
-                        </requirementText>
+                        <requirementText>NOARK 13.2.6 (V): Loggingen skal være konfigurerbar. Som et minimum skal anbefalte loggingsregler kunne settes av eller på av system- eller arkivadministrator </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>NOARK 13.2.8 (V): Sporingsinformasjon skal være enkel å bla i, søke i og
-                            analysere, enten ved hjelp av funksjonalitet i sak- og arkivløsningen, eller ved hjelp av et
-                            tredjepartsprogram. Leverandøren skal angi hvilket av alternativene som er tilgjengelige.
-                        </requirementText>
+                        <requirementText>NOARK 13.2.8 (V): Sporingsinformasjon skal være enkel å bla i, søke i og analysere, enten ved hjelp av funksjonalitet i sak- og arkivløsningen, eller ved hjelp av et tredjepartsprogram. Leverandøren skal angi hvilket av alternativene som er tilgjengelige. </requirementText>
                         <priority>2 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>6</showOrder>
-                        <requirementText>NOARK 13.2.9 (V): Sporingsinformasjon skal kunne leses eller skrives ut sortert
-                            etter minst disse kriteriene: 1) Kronologisk etter når hendelsen faktisk ble registrert i
-                            loggen, 2) Etter brukers påloggingsidentifikator, deretter kronologisk, 3) Etter
-                            organisatorisk enhet, deretter kronologisk
-                        </requirementText>
+                        <requirementText>NOARK 13.2.9 (V): Sporingsinformasjon skal kunne leses eller skrives ut sortert etter minst disse kriteriene: 1) Kronologisk etter når hendelsen faktisk ble registrert i loggen, 2) Etter brukers påloggingsidentifikator, deretter kronologisk, 3) Etter organisatorisk enhet, deretter kronologisk </requirementText>
                         <priority>2</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>7</noarkRequirement>
-                        <showOrder>NOARK 13.2.11 (V): Som et konfigurerbart valg skal sporingsinformasjon kunne lagres
-                            internt i Noark 5-løsningen. Denne varianten er et alternativ til eksterne logger. Logg som
-                            lagres internt i arkivet vil primært være aktuelt for hendelser som det kan være relevant å
-                            gjøre tilgjengelig for brukere av ulike eksterne fagsystemer som bruker samme arkiv, for
-                            eksempel: 1) Lagring av ny eller endret informasjon i mapper, registreringer,
-                            dokumentbeskrivelser, klassifiseringsskjemaer og arkivstruktur, 2) Informasjon om
-                            konvertering av dokumenters filformat, lagring av nye varianter eller versjoner av
-                            dokumenter
-                        </showOrder>
+                        <showOrder>NOARK 13.2.11 (V): Som et konfigurerbart valg skal sporingsinformasjon kunne lagres internt i Noark 5-løsningen. Denne varianten er et alternativ til eksterne logger. Logg som lagres internt i arkivet vil primært være aktuelt for hendelser som det kan være relevant å gjøre tilgjengelig for brukere av ulike eksterne fagsystemer som bruker samme arkiv, for eksempel: 1) Lagring av ny eller endret informasjon i mapper, registreringer, dokumentbeskrivelser, klassifiseringsskjemaer og arkivstruktur, 2) Informasjon om konvertering av dokumenters filformat, lagring av nye varianter eller versjoner av dokumenter </showOrder>
                         <requirementText>1</requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>8</showOrder>
-                        <requirementText>NOARK 13.3.6 (V): Pålogging av brukere med ordinære roller, som gis tilgang til
-                            NOARK 5 kjernen enten direkte eller indirekte via integrert løsning. Følgende informasjon
-                            skal også kunne logges: 1) Valgt rolle eller tilgangsprofil for brukeren 2)
-                            Terminalidentitet, alternativt MAC-adresse eller IP-adresse
-                        </requirementText>
+                        <requirementText>NOARK 13.3.6 (V): Pålogging av brukere med ordinære roller, som gis tilgang til NOARK 5 kjernen enten direkte eller indirekte via integrert løsning. Følgende informasjon skal også kunne logges: 1) Valgt rolle eller tilgangsprofil for brukeren 2) Terminalidentitet, alternativt MAC-adresse eller IP-adresse </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>9</showOrder>
-                        <requirementText>NOARK 13.3.7 (V): For alle typer pålogging skal mislykkede / avviste forsøk
-                            logges, med følgende informasjon: 1) Angitt – gyldig eller ugyldig – påloggings
-                            identifikator, 2) Angitt passord eller eventuell annen legitimering 3) Dato og tidspunkt for
-                            påloggingsforsøket, 4) Terminalidentitet, alternativt MAC-adresse eller IP-adresse
-                        </requirementText>
+                        <requirementText>NOARK 13.3.7 (V): For alle typer pålogging skal mislykkede / avviste forsøk logges, med følgende informasjon: 1) Angitt – gyldig eller ugyldig – påloggings identifikator, 2) Angitt passord eller eventuell annen legitimering 3) Dato og tidspunkt for påloggingsforsøket, 4) Terminalidentitet, alternativt MAC-adresse eller IP-adresse </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>10</showOrder>
-                        <requirementText>NOARK 13.3.8 (V): Logging for å kontrollere at handlinger er i tråd med
-                            tjenestlig behov bør være konfigurerbar på detaljert nivå. 1) Angi/avgrense hvilke
-                            autorisasjoner (roller, profiler eller lignende) det skal iverksettes logging for 2) Angi om
-                            det bare skal registreres at en endring har funnet sted, eller om også gammel verdi/ny verdi
-                            skal registreres 3) Angi om lesing av objekter skal logges 4) Angi om søketilslag skal
-                            logges 5) Angi om bruk av funksjoner for utskrift skal logges 6) Angi om bruk av funksjoner
-                            for lagring eller eksport av dokument eller metadata til filområde eller annet program
-                            utenfor Noark 5 kjernen skal logges
-                        </requirementText>
+                        <requirementText>NOARK 13.3.8 (V): Logging for å kontrollere at handlinger er i tråd med tjenestlig behov bør være konfigurerbar på detaljert nivå. 1) Angi/avgrense hvilke autorisasjoner (roller, profiler eller lignende) det skal iverksettes logging for 2) Angi om det bare skal registreres at en endring har funnet sted, eller om også gammel verdi/ny verdi skal registreres 3) Angi om lesing av objekter skal logges 4) Angi om søketilslag skal logges 5) Angi om bruk av funksjoner for utskrift skal logges 6) Angi om bruk av funksjoner for lagring eller eksport av dokument eller metadata til filområde eller annet program utenfor Noark 5 kjernen skal logges </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>11</showOrder>
-                        <requirementText>NOARK 13.4.2 (V): Ved første lagring av nytt inngående elektronisk dokument,
-                            som enten er skannet inn eller mottatt elektronisk, skal følgende logges: 1) Identifikator
-                            eller filnavn og plassering for dokumentet, som kan brukes til entydig identifikasjon i
-                            arkivet 2) Dato og tidspunkt for innskanning eller ankomst til elektronisk mottaksenhet
-                            (altså normalt før saksbehandler har begynt behandlingen) 3) Hvem: Løsning, organisatorisk
-                            enhet, evt. bruker eller rolle, som har utført lagringen 4) Dokumentformat (filtype,
-                            ekstensjon, mime vedleggstype eller lignende) 5) Eventuelt nytt dokumentformat dersom
-                            dokumentet er konvertert ved mottak 6) Lesbart = j/n, resultat av kontroll om program for å
-                            lese, fremføre eller redigere dokumentformatet var tilgjenglig ved opprettelsestidspunktet
-                        </requirementText>
+                        <requirementText>NOARK 13.4.2 (V): Ved første lagring av nytt inngående elektronisk dokument, som enten er skannet inn eller mottatt elektronisk, skal følgende logges: 1) Identifikator eller filnavn og plassering for dokumentet, som kan brukes til entydig identifikasjon i arkivet 2) Dato og tidspunkt for innskanning eller ankomst til elektronisk mottaksenhet (altså normalt før saksbehandler har begynt behandlingen) 3) Hvem: Løsning, organisatorisk enhet, evt. bruker eller rolle, som har utført lagringen 4) Dokumentformat (filtype, ekstensjon, mime vedleggstype eller lignende) 5) Eventuelt nytt dokumentformat dersom dokumentet er konvertert ved mottak 6) Lesbart = j/n, resultat av kontroll om program for å lese, fremføre eller redigere dokumentformatet var tilgjenglig ved opprettelsestidspunktet </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>12</showOrder>
-                        <requirementText>NOARK 13.4.3 (V): Ved første lagring av nytt dokument produsert i NOARK
-                            5-løsningen skal følgende logges: 1) Identifikator eller filnavn og plassering for
-                            dokumentet, som kan brukes til entydig identifikasjon i arkivet 2) Dato og tidspunkt for
-                            første lagring av identifikator som nevnt ovenfor 3) Bruker og rolle som har lagret
-                            dokumentet, og eventuelt hvilket fagsystem som er brukt 4) Dokumentets produksjonsformat
-                            (filtype, ekstensjon, mime vedleggstype eller lignende)
-                        </requirementText>
+                        <requirementText>NOARK 13.4.3 (V): Ved første lagring av nytt dokument produsert i NOARK 5-løsningen skal følgende logges: 1) Identifikator eller filnavn og plassering for dokumentet, som kan brukes til entydig identifikasjon i arkivet 2) Dato og tidspunkt for første lagring av identifikator som nevnt ovenfor 3) Bruker og rolle som har lagret dokumentet, og eventuelt hvilket fagsystem som er brukt 4) Dokumentets produksjonsformat (filtype, ekstensjon, mime vedleggstype eller lignende) </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>13</showOrder>
-                        <requirementText>NOARK 13.4.5 (V): Sletting av dokumenter skal logges. Følgende skal logges i
-                            tillegg til obligatoriske elementer i kravet ovenfor: 1) Identifikator eller angivelse av
-                            filnavn og plassering som dokumentet er slettet fra 2) Kode eller beskrivelse av regel for
-                            rutinisert,automatisk sletting (opprydding av overflødige versjoner etc.) 3) Eventuelt
-                            angitt begrunnelse ved manuell sletting
-                        </requirementText>
+                        <requirementText>NOARK 13.4.5 (V): Sletting av dokumenter skal logges. Følgende skal logges i tillegg til obligatoriske elementer i kravet ovenfor: 1) Identifikator eller angivelse av filnavn og plassering som dokumentet er slettet fra 2) Kode eller beskrivelse av regel for rutinisert,automatisk sletting (opprydding av overflødige versjoner etc.) 3) Eventuelt angitt begrunnelse ved manuell sletting </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>14</showOrder>
-                        <requirementText>NOARK 13.4.6 (V): Konvertering av dokumenter (endring av format) skal logges.
-                            Følgende kommer i tillegg til obligatoriske loggdata: 1) Gammelt filformat 2) Nytt filformat
-                            3) Tidspunkt for konvertering, oppgavens varighet 4) Eventuelle statuskoder/feilmeldinger
-                            fra konverteringsprogrammet
-                        </requirementText>
+                        <requirementText>NOARK 13.4.6 (V): Konvertering av dokumenter (endring av format) skal logges. Følgende kommer i tillegg til obligatoriske loggdata: 1) Gammelt filformat 2) Nytt filformat 3) Tidspunkt for konvertering, oppgavens varighet 4) Eventuelle statuskoder/feilmeldinger fra konverteringsprogrammet </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>15</showOrder>
-                        <requirementText>NOARK 13.4.7 (V): Ved systemgenerert/batch konvertering av dokumenter (endring
-                            av format) skal også opplysninger om utvalgskriteriene, starttidspunkt og varighet for hele
-                            jobben logges.
-                        </requirementText>
+                        <requirementText>NOARK 13.4.7 (V): Ved systemgenerert/batch konvertering av dokumenter (endring av format) skal også opplysninger om utvalgskriteriene, starttidspunkt og varighet for hele jobben logges. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>16</showOrder>
-                        <requirementText>Løsningen skal tilfredsstille alle valgfrie Noark 5-krav som gjelder logging av
-                            hendelser fra og med krav nr 13.4.17 til og med krav nr 13.4.36. Leverandøren skal angi
-                            hvilke krav som eventuelt ikke oppfylles, samt angi årsak og konsekvenser av dette.
-                        </requirementText>
+                        <requirementText>Løsningen skal tilfredsstille alle valgfrie Noark 5-krav som gjelder logging av hendelser fra og med krav nr 13.4.17 til og med krav nr 13.4.36. Leverandøren skal angi hvilke krav som eventuelt ikke oppfylles, samt angi årsak og konsekvenser av dette. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                 </requirements>
@@ -5808,17 +4103,13 @@
                 <requirement>
                     <noarkRequirement>false</noarkRequirement>
                     <showOrder>1</showOrder>
-                    <requirementText>Alle data som registreres i systemet skal gjennomgå den samme valideringen og
-                        kontrollen uavhengig av om dataene registreres manuelt, eller ved elektronisk overføring.
-                    </requirementText>
+                    <requirementText>Alle data som registreres i systemet skal gjennomgå den samme valideringen og kontrollen uavhengig av om dataene registreres manuelt, eller ved elektronisk overføring. </requirementText>
                     <priority>1</priority>
                 </requirement>
                 <requirement>
                     <noarkRequirement>false</noarkRequirement>
                     <showOrder>2</showOrder>
-                    <requirementText>Feilregistreringer eller mangelfull registrering skal varsles umiddelbart i
-                        skjermbilder og skal kunne rettes direkte der.
-                    </requirementText>
+                    <requirementText>Feilregistreringer eller mangelfull registrering skal varsles umiddelbart i skjermbilder og skal kunne rettes direkte der. </requirementText>
                     <priority>1</priority>
                 </requirement>
                 <requirements></requirements>
@@ -5839,9 +4130,7 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Arkivdatabasen skal være strukturert i henhold til Noark 5 kravene og lagre all
-                            arkivdata i denne strukturen.
-                        </requirementText>
+                        <requirementText>Arkivdatabasen skal være strukturert i henhold til Noark 5 kravene og lagre all arkivdata i denne strukturen. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
@@ -5853,24 +4142,19 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Arkivdatabasen skal være logisk adskilt fra resten av systemet.
-                        </requirementText>
+                        <requirementText>Arkivdatabasen skal være logisk adskilt fra resten av systemet. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>Arkivdatabasen skal ha Noark5 tjenestegrensesnitt for alle tjenester i basen,
-                            uavhengig av konformitetsnivåer.
-                        </requirementText>
+                        <requirementText>Arkivdatabasen skal ha Noark5 tjenestegrensesnitt for alle tjenester i basen, uavhengig av konformitetsnivåer. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Arkivdatabasen (alle filer og metadata) skal uavhengig av leverandør og teknisk
-                            kompetanse kunne eksporteres til arkivformat både løpende og ved avslutning/periodisering.
-                        </requirementText>
+                        <requirementText>Arkivdatabasen (alle filer og metadata) skal uavhengig av leverandør og teknisk kompetanse kunne eksporteres til arkivformat både løpende og ved avslutning/periodisering. </requirementText>
                         <priority>1</priority>
                     </requirement>
                 </requirements>
@@ -5887,23 +4171,19 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Systemet skal kjøres på virtuell plattform (i dag benyttes VMware)
-                        </requirementText>
+                        <requirementText>Systemet skal kjøres på virtuell plattform (i dag benyttes VMware) </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Systemet skal kunne kjøres med databasen MS SQL versjon 2008 og nyere.
-                        </requirementText>
+                        <requirementText>Systemet skal kunne kjøres med databasen MS SQL versjon 2008 og nyere. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Det bes opplyst hvilke andre nettlesere enn Microsoft Internet Explorer
-                            systemet støtter.
-                        </requirementText>
+                        <requirementText>Det bes opplyst hvilke andre nettlesere enn Microsoft Internet Explorer systemet støtter. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
@@ -5915,34 +4195,25 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>For eventuelle framtidig konvertering må det være mulig å eksportere data fra
-                            systemet til eksterne filer.
-                        </requirementText>
+                        <requirementText>For eventuelle framtidig konvertering må det være mulig å eksportere data fra systemet til eksterne filer. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>6</showOrder>
-                        <requirementText>Eksisterende historiske data skal overføres/konverteres til historisk base i
-                            det nye systemet.
-                        </requirementText>
+                        <requirementText>Eksisterende historiske data skal overføres/konverteres til historisk base i det nye systemet. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>7</showOrder>
-                        <requirementText>Klienter må kunne rulles ut vha. utrullingsverktøy Altiris og MS SCCM. Det må
-                            også gjelde alle fremtidige oppgraderinger av klienter.
-                        </requirementText>
+                        <requirementText>Klienter må kunne rulles ut vha. utrullingsverktøy Altiris og MS SCCM. Det må også gjelde alle fremtidige oppgraderinger av klienter. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>8</showOrder>
-                        <requirementText>Når det kommer nye versjoner av Internet Explorer, Citrix, MS sql eller
-                            virtuelle servere, må leverandør si noe om hvor lang tid det vil ta før sak/arkiv-systemet
-                            støtter nyeste versjon
-                        </requirementText>
+                        <requirementText>Når det kommer nye versjoner av Internet Explorer, Citrix, MS sql eller virtuelle servere, må leverandør si noe om hvor lang tid det vil ta før sak/arkiv-systemet støtter nyeste versjon </requirementText>
                         <priority>O (i)</priority>
                     </requirement>
                 </requirements>
@@ -5965,16 +4236,13 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Dokumenter skal lagres i database og ikke direkte i filsystemet.
-                        </requirementText>
+                        <requirementText>Dokumenter skal lagres i database og ikke direkte i filsystemet. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Leverandøren skal beskrive anbefalt design for / arkitekturmessig oppsett av
-                            samtlige servere og applikasjoner som løsningen består av.
-                        </requirementText>
+                        <requirementText>Leverandøren skal beskrive anbefalt design for / arkitekturmessig oppsett av samtlige servere og applikasjoner som løsningen består av. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
@@ -5986,47 +4254,31 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Beskriv anbefalt maskinvarekrav til de servertypene som den anbefalte løsningen
-                            består av; databaseserver (e), applikasjonsserver (e), evt. webserver(e) etc.
-                        </requirementText>
+                        <requirementText>Beskriv anbefalt maskinvarekrav til de servertypene som den anbefalte løsningen består av; databaseserver (e), applikasjonsserver (e), evt. webserver(e) etc. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>6</showOrder>
-                        <requirementText>Organisasjonen har 4 stk Dell R730 servere med 2 cpu’er, 12 kjerner som
-                            plattform for VMWare. Systemet er planlagt implementert der.
-                        </requirementText>
+                        <requirementText>Organisasjonen har 4 stk Dell R730 servere med 2 cpu’er, 12 kjerner som plattform for VMWare. Systemet er planlagt implementert der. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>7</showOrder>
-                        <requirementText>Når nye versjoner/oppgraderinger lanseres, skal leverandøren utarbeide
-                            dokumentasjon på gjennomføringen. Kundens it-personell får derved mulighet til å gjennomføre
-                            oppgraderingen selv. 6 Leverandøren skal dokumentere at saksbehandlerklienten kan kjøres i
-                            et Citrix-miljø på Citrix-servere, hvilke versjoner de har erfaringer fra, og minimumskravet
-                            til Citrix-versjon på server.
-                        </requirementText>
+                        <requirementText>Når nye versjoner/oppgraderinger lanseres, skal leverandøren utarbeide dokumentasjon på gjennomføringen. Kundens it-personell får derved mulighet til å gjennomføre oppgraderingen selv. 6 Leverandøren skal dokumentere at saksbehandlerklienten kan kjøres i et Citrix-miljø på Citrix-servere, hvilke versjoner de har erfaringer fra, og minimumskravet til Citrix-versjon på server. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>8</showOrder>
-                        <requirementText>Systemet må fungere problemfritt i et Windows 2008 R2 eller nyere servermiljø.
-                            Windows Server 2008 R2 / 2012 R2 er preferert. Leverandør skal oppgi minimum og anbefalt
-                            server OS versjon. Dersom det kreves en bestemt versjon som minimum, og dette medfører at
-                            Kunden må foreta en oppgradering/nedgradering, vil eventuelle omkostninger i forbindelse med
-                            dette bli lagt til ved vurderingen av tilbudet.
-                        </requirementText>
+                        <requirementText>Systemet må fungere problemfritt i et Windows 2008 R2 eller nyere servermiljø. Windows Server 2008 R2 / 2012 R2 er preferert. Leverandør skal oppgi minimum og anbefalt server OS versjon. Dersom det kreves en bestemt versjon som minimum, og dette medfører at Kunden må foreta en oppgradering/nedgradering, vil eventuelle omkostninger i forbindelse med dette bli lagt til ved vurderingen av tilbudet. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>9</showOrder>
-                        <requirementText>Beskriv anbefalt løsning for komplett backup av systemet (tekniske
-                            spesifikasjoner).
-                        </requirementText>
+                        <requirementText>Beskriv anbefalt løsning for komplett backup av systemet (tekniske spesifikasjoner). </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                 </requirements>
@@ -6043,64 +4295,43 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Gjeldende standard konfigurasjon for pc som benyttes som tykk
-                            saksbehandlerklinet er prosessor av type Intel I5 (4. generasjon og høyere) og 8 Gb ram
-                            hukommelse. Beskriv maskinvarekrav til PCer som kjører tykk saksbehandlerklienten. Både
-                            minimumskrav og anbefalte krav beskrives.
-                        </requirementText>
+                        <requirementText>Gjeldende standard konfigurasjon for pc som benyttes som tykk saksbehandlerklinet er prosessor av type Intel I5 (4. generasjon og høyere) og 8 Gb ram hukommelse. Beskriv maskinvarekrav til PCer som kjører tykk saksbehandlerklienten. Både minimumskrav og anbefalte krav beskrives. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Tykk saksbehandlerklient skal kjøres på PC’er med Windows 7 og nyere OS.
-                        </requirementText>
+                        <requirementText>Tykk saksbehandlerklient skal kjøres på PC’er med Windows 7 og nyere OS. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Systemet skal ha en webbasert saksbehandlerklient der alle webbaserte
-                            funksjoner fungerer i de mest brukte nettleserne. Systemet skal fungere i Internet Explorer
-                            11.
-                        </requirementText>
+                        <requirementText>Systemet skal ha en webbasert saksbehandlerklient der alle webbaserte funksjoner fungerer i de mest brukte nettleserne. Systemet skal fungere i Internet Explorer 11. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>Hvis systemet forutsetter bruk av et bestemt program (f.eks. ved innskanning
-                            eller visning av innskannede dokumenter) skal leverandøren oppgi dette i tilbudet.
-                        </requirementText>
+                        <requirementText>Hvis systemet forutsetter bruk av et bestemt program (f.eks. ved innskanning eller visning av innskannede dokumenter) skal leverandøren oppgi dette i tilbudet. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Leverandøren skal beskrive hvilke tekstbehandlingsprogram som støttes. Systemet
-                            skal fungere med Microsoft Office 2010 og nyere. Leverandøren skal også beskrive hvilken
-                            politikk Leverandøren har for å sikre kompatibilitet med fremtidige versjoner av de
-                            tekstbehandlingsprogram som støttes.
-                        </requirementText>
+                        <requirementText>Leverandøren skal beskrive hvilke tekstbehandlingsprogram som støttes. Systemet skal fungere med Microsoft Office 2010 og nyere. Leverandøren skal også beskrive hvilken politikk Leverandøren har for å sikre kompatibilitet med fremtidige versjoner av de tekstbehandlingsprogram som støttes. </requirementText>
                         <priority>2 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>6</showOrder>
-                        <requirementText>Systemet skal oppleves raskt, forutsigbart og konsistent av brukerne når det
-                            gjelder ytelse og responstider for både web-basert løsning og tykk saksbehandlerklient.
-                            Leverandøren skal beskrive hvordan dette skal oppfylles og hvilke forutsetninger som må være
-                            oppfylt (herunder linjekapasitet) for at de etterfølgende eksplisitte krav som stilles skal
-                            være mulig.
-                        </requirementText>
+                        <requirementText>Systemet skal oppleves raskt, forutsigbart og konsistent av brukerne når det gjelder ytelse og responstider for både web-basert løsning og tykk saksbehandlerklient. Leverandøren skal beskrive hvordan dette skal oppfylles og hvilke forutsetninger som må være oppfylt (herunder linjekapasitet) for at de etterfølgende eksplisitte krav som stilles skal være mulig. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>7</showOrder>
-                        <requirementText>Leverandøren skal beskrive løsningens skalerbarhet mht ytelse ved økt antall
-                            brukere og økt innholdsvolum/saker.
-                        </requirementText>
+                        <requirementText>Leverandøren skal beskrive løsningens skalerbarhet mht ytelse ved økt antall brukere og økt innholdsvolum/saker. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                 </requirements>
@@ -6117,42 +4348,31 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Leverandøren skal opplyse om eventuelle ytterligere krav som stilles til
-                            komplett løsning, og som ikke er etterspurt her i andre krav. Både minimumskrav og anbefalte
-                            krav beskrives.
-                        </requirementText>
+                        <requirementText>Leverandøren skal opplyse om eventuelle ytterligere krav som stilles til komplett løsning, og som ikke er etterspurt her i andre krav. Både minimumskrav og anbefalte krav beskrives. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Systemet skal fungere med Microsoft Exchange 2013 som epostserver løsning.
-                        </requirementText>
+                        <requirementText>Systemet skal fungere med Microsoft Exchange 2013 som epostserver løsning. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Systemet skal fungere tilfredsstillende med Microsoft Outlook som
-                            epost-klient.
-                        </requirementText>
+                        <requirementText>Systemet skal fungere tilfredsstillende med Microsoft Outlook som epost-klient. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>Organisasjonen har en eksisterende lisensavtale med Microsoft. Ved behov for
-                            Microsoft lisenser skal Leverandøren opplyse om hvilke lisenser som er påkrevet.
-                        </requirementText>
+                        <requirementText>Organisasjonen har en eksisterende lisensavtale med Microsoft. Ved behov for Microsoft lisenser skal Leverandøren opplyse om hvilke lisenser som er påkrevet. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Redegjør for hvordan løsningen ivaretar de sju overordnede prinsipper for
-                            IKT-arkitektur beskrevet i Difis dokument ”Overordnede IKT-arkitekturprinsipper for
-                            offentlig sektor”.
-                        </requirementText>
+                        <requirementText>Redegjør for hvordan løsningen ivaretar de sju overordnede prinsipper for IKT-arkitektur beskrevet i Difis dokument ”Overordnede IKT-arkitekturprinsipper for offentlig sektor”. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                 </requirements>
@@ -6173,98 +4393,67 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Det er svært viktig for oppdragsgiver at valgt system er tilrettelagt for
-                            komplett Noark5 tjenestegrensesnitt som skal kunne benyttes mot alle tjenester i
-                            Noark5-systemet, uavhengig av konformitetsnivåene i standarden. Leverandøren skal redegjøre
-                            for hvilke planer som foreligger i forhold til implementering av Noark5 tjenestegrensesnitt.
-                            Tidsplan skal inngå i redegjørelsen.
-                        </requirementText>
+                        <requirementText>Det er svært viktig for oppdragsgiver at valgt system er tilrettelagt for komplett Noark5 tjenestegrensesnitt som skal kunne benyttes mot alle tjenester i Noark5-systemet, uavhengig av konformitetsnivåene i standarden. Leverandøren skal redegjøre for hvilke planer som foreligger i forhold til implementering av Noark5 tjenestegrensesnitt. Tidsplan skal inngå i redegjørelsen. </requirementText>
                         <priority>O (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Systemet skal håndtere eksport/import av data i åpne standarder, blant annet
-                            for å sikre integrasjon med framtidige portalløsninger.
-                        </requirementText>
+                        <requirementText>Systemet skal håndtere eksport/import av data i åpne standarder, blant annet for å sikre integrasjon med framtidige portalløsninger. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Systemet skal ha mulighet for datafangst ved bruk av IOS, Android Microsoft og
-                            eventuelt andre håndholdte enheter. Leverandør bes beskrive løsningen.
-                        </requirementText>
+                        <requirementText>Systemet skal ha mulighet for datafangst ved bruk av IOS, Android Microsoft og eventuelt andre håndholdte enheter. Leverandør bes beskrive løsningen. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>Systemet skal ha mulighet for dokumentfangst fra ulike typer
-                            kommunikasjonskanaler som f.eks SMS, Chat og sosiale media. Løsningen skal angi hvilken
-                            kommunikasjonskanal som er benyttet ved lagring av metadata. Leverandøren bes beskrive
-                            løsningen.
-                        </requirementText>
+                        <requirementText>Systemet skal ha mulighet for dokumentfangst fra ulike typer kommunikasjonskanaler som f.eks SMS, Chat og sosiale media. Løsningen skal angi hvilken kommunikasjonskanal som er benyttet ved lagring av metadata. Leverandøren bes beskrive løsningen. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Alle data og konfigurasjonsinnstillinger skal kunne eksporteres og importeres,
-                            fortrinnsvis ved hjelp av XML.
-                        </requirementText>
+                        <requirementText>Alle data og konfigurasjonsinnstillinger skal kunne eksporteres og importeres, fortrinnsvis ved hjelp av XML. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>6</showOrder>
-                        <requirementText>Løsningen skal være tilrettelagt for sømløs integrering med andre systemer,
-                            herunder pålogging, e-post og fagsystemer. Leverandøren skal beskrive tilgjengelige API’er
-                            (evt. som referanse til relevant systemdokumentasjon), samt hvilke eventuelle kostnadsposter
-                            som normalt må påregnes ved integrasjon av andre systemer med løsningen.
-                        </requirementText>
+                        <requirementText>Løsningen skal være tilrettelagt for sømløs integrering med andre systemer, herunder pålogging, e-post og fagsystemer. Leverandøren skal beskrive tilgjengelige API’er (evt. som referanse til relevant systemdokumentasjon), samt hvilke eventuelle kostnadsposter som normalt må påregnes ved integrasjon av andre systemer med løsningen. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>7</showOrder>
-                        <requirementText>Standardiseringsrådets referansekatalog for IKT-standarder i offentlig sektor
-                            gir føringer for hvilke åpne offentlige virksomheter må hastøtte for. Beskriv hvordan
-                            løsningen forholder seg til disse utvekslingsformatene.
-                        </requirementText>
+                        <requirementText>Standardiseringsrådets referansekatalog for IKT-standarder i offentlig sektor gir føringer for hvilke åpne offentlige virksomheter må hastøtte for. Beskriv hvordan løsningen forholder seg til disse utvekslingsformatene. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>8</showOrder>
-                        <requirementText>Systemet skal ha muligheter til utveksling av data og integrasjon med andre
-                            systemer via standardiserte, allment aksepterte, åpne grensesnitt (som f.eks. XML).
-                        </requirementText>
+                        <requirementText>Systemet skal ha muligheter til utveksling av data og integrasjon med andre systemer via standardiserte, allment aksepterte, åpne grensesnitt (som f.eks. XML). </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>9</showOrder>
-                        <requirementText>Systemet skal være kompatibelt med elektronisk signatur valgt for offentlig
-                            forvaltning.
-                        </requirementText>
+                        <requirementText>Systemet skal være kompatibelt med elektronisk signatur valgt for offentlig forvaltning. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>10</showOrder>
-                        <requirementText>Systemet skal ha integrasjon mot Noark 5 kjerne, basert på åpen kildekode.
-                        </requirementText>
+                        <requirementText>Systemet skal ha integrasjon mot Noark 5 kjerne, basert på åpen kildekode. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>11</showOrder>
-                        <requirementText>Leverandøren skal redegjøre for hvordan NOARK5-kjernen er bygd opp for å oppnå
-                            integrasjon og samhandling mellom sak – og arkiv og fagsystemene. Leverandøren skal herunder
-                            beskrive muligheter og begrensninger knyttet til løsningen når det gjelder å benytte kjernen
-                            som lagringsplass for data fra fagsystemer.
-                        </requirementText>
+                        <requirementText>Leverandøren skal redegjøre for hvordan NOARK5-kjernen er bygd opp for å oppnå integrasjon og samhandling mellom sak – og arkiv og fagsystemene. Leverandøren skal herunder beskrive muligheter og begrensninger knyttet til løsningen når det gjelder å benytte kjernen som lagringsplass for data fra fagsystemer. </requirementText>
                         <priority>O (i)</priority>
                     </requirement>
                 </requirements>
@@ -6281,68 +4470,43 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>0</showOrder>
-                        <requirementText>Å sikre organisasjonens innbyggere en enkel og papirløs metode for innsending
-                            av søknader etc til forvaltningen. Effektivisere arbeidet i forvaltningen med registrering
-                            og behandling av mottatte skjema.
-                        </requirementText>
+                        <requirementText>Å sikre organisasjonens innbyggere en enkel og papirløs metode for innsending av søknader etc til forvaltningen. Effektivisere arbeidet i forvaltningen med registrering og behandling av mottatte skjema. </requirementText>
                         <priority></priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>NOARK 6.3.20 (V) Det skal finnes funksjonalitet for å hente inn både relevante
-                            svardata og transaksjonsopplysninger fra elektroniske skjemaer, og legge disse inn som
-                            mappe, registrering, dokumentbeskrivelse og dokument i en automatisert prosess.
-                        </requirementText>
+                        <requirementText>NOARK 6.3.20 (V) Det skal finnes funksjonalitet for å hente inn både relevante svardata og transaksjonsopplysninger fra elektroniske skjemaer, og legge disse inn som mappe, registrering, dokumentbeskrivelse og dokument i en automatisert prosess. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>true</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>NOARK 6.3.25 (V) For dynamiske skjemaer skal informasjon om aktuell versjon av
-                            skjema og presentasjonsprogramvare lagres sammen med eller som del av resultatdatasettet,
-                            innfelt i den skjemaversjonen som ble brukt ved utfylling av skjemaet.
-                        </requirementText>
+                        <requirementText>NOARK 6.3.25 (V) For dynamiske skjemaer skal informasjon om aktuell versjon av skjema og presentasjonsprogramvare lagres sammen med eller som del av resultatdatasettet, innfelt i den skjemaversjonen som ble brukt ved utfylling av skjemaet. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>I en tid med stadig økende digitalisering av offentlige tjenester er det behov
-                            for en egen «skjemamodul» integrert med sak/arkiv-systemet. Leverandøren bes opplyse om en
-                            slik modul er på plass, og evt. hvilke eksterne skjemamoduler det er utviklet integrasjon
-                            mot. Leverandør bes også beskrive i hvilken grad Kunden selv kan designe egne skjemaer
-                            dersom en skjemamodul er på plass, samt liste opp de «ferdige» skjemaene Kunden i så fall
-                            vil få tilgang til.
-                        </requirementText>
+                        <requirementText>I en tid med stadig økende digitalisering av offentlige tjenester er det behov for en egen «skjemamodul» integrert med sak/arkiv-systemet. Leverandøren bes opplyse om en slik modul er på plass, og evt. hvilke eksterne skjemamoduler det er utviklet integrasjon mot. Leverandør bes også beskrive i hvilken grad Kunden selv kan designe egne skjemaer dersom en skjemamodul er på plass, samt liste opp de «ferdige» skjemaene Kunden i så fall vil få tilgang til. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Løsningen skal tilrettelegges for mottak av elektroniske skjema som er
-                            tilgjengeliggjort via organisasjonens internettsider.
-                        </requirementText>
+                        <requirementText>Løsningen skal tilrettelegges for mottak av elektroniske skjema som er tilgjengeliggjort via organisasjonens internettsider. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>Tilrettelegging for mottak av elektroniske skjema skal gjøres slik at
-                            organisasjonen selv kan implementere elektroniske skjema i sak- og arkivløsningen ettersom
-                            man får ytterligere skjema tilgjengeliggjort elektronisk på internettsidene. Leverandøren
-                            skal gi en kort beskrivelse av hvordan løsningen tilrettelegger for dette.
-                        </requirementText>
+                        <requirementText>Tilrettelegging for mottak av elektroniske skjema skal gjøres slik at organisasjonen selv kan implementere elektroniske skjema i sak- og arkivløsningen ettersom man får ytterligere skjema tilgjengeliggjort elektronisk på internettsidene. Leverandøren skal gi en kort beskrivelse av hvordan løsningen tilrettelegger for dette. </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Leverandøren skal gi en beskrivelse av hvilke krav som stilles til de
-                            elektroniske skjemaene, og eventuelle andre forhold på kundens side, for at leverandøren
-                            skal kunne oppfylle NOARK5-krav 6.3.20 til 6.3.25 (krav til elektroniske skjema for
-                            utfylling over internett).
-                        </requirementText>
+                        <requirementText>Leverandøren skal gi en beskrivelse av hvilke krav som stilles til de elektroniske skjemaene, og eventuelle andre forhold på kundens side, for at leverandøren skal kunne oppfylle NOARK5-krav 6.3.20 til 6.3.25 (krav til elektroniske skjema for utfylling over internett). </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                 </requirements>
@@ -6359,45 +4523,31 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Det er særlig viktig for den nye organisasjonen at det legges til rette for å
-                            kunne hente oppdatert kartinformasjon og registerinformasjon (Matrikkelen) inn i
-                            sakssystemet. I valg av nytt sakssystem vil det derfor legges stor vekt på tilrettelegging
-                            for geointegrasjon. I skrivende stund er det ennå ikke bestemt hvilket kartsystem den nye
-                            organisasjonen satser på å ta i bruk.
-                        </requirementText>
+                        <requirementText>Det er særlig viktig for den nye organisasjonen at det legges til rette for å kunne hente oppdatert kartinformasjon og registerinformasjon (Matrikkelen) inn i sakssystemet. I valg av nytt sakssystem vil det derfor legges stor vekt på tilrettelegging for geointegrasjon. I skrivende stund er det ennå ikke bestemt hvilket kartsystem den nye organisasjonen satser på å ta i bruk. </requirementText>
                         <priority>O (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Sak-arkivløsningen skal støtte siste versjon av Geointegrasjonstandarden
-                            (Plandialog).
-                        </requirementText>
+                        <requirementText>Sak-arkivløsningen skal støtte siste versjon av Geointegrasjonstandarden (Plandialog). </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Løsningen skal blant annet gi mulighet for: 1) Kontroll av oppgitt adresse i
-                            Matrikkelen, 2) Starte kartsystem og vise aktuell arealplan 3) Hente hjemmelshaver til sak –
-                            arkiv for eiendommer innenfor et planområde eller annet digitalisert område i kartsystemet
-                            4) Starte kartsystem og vise aktuell eiendom . OBS. Listen er ikke uttømmende.
-                        </requirementText>
+                        <requirementText>Løsningen skal blant annet gi mulighet for: 1) Kontroll av oppgitt adresse i Matrikkelen, 2) Starte kartsystem og vise aktuell arealplan 3) Hente hjemmelshaver til sak – arkiv for eiendommer innenfor et planområde eller annet digitalisert område i kartsystemet 4) Starte kartsystem og vise aktuell eiendom . OBS. Listen er ikke uttømmende. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>Løsningen skal legge til rette for geointegrasjon mot oppmålingssaker.
-                            (Oppmålingsdialog)
-                        </requirementText>
+                        <requirementText>Løsningen skal legge til rette for geointegrasjon mot oppmålingssaker. (Oppmålingsdialog) </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Det skal redegjøres for mulig geointegrasjon mot byggesaker (Byggesaksdialog)
-                        </requirementText>
+                        <requirementText>Det skal redegjøres for mulig geointegrasjon mot byggesaker (Byggesaksdialog) </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                 </requirements>
@@ -6414,45 +4564,31 @@
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Det er særlig viktig for den nye organisasjonen at det legges til rette for å
-                            kunne hente oppdatert kartinformasjon og registerinformasjon (Matrikkelen) inn i
-                            sakssystemet. I valg av nytt sakssystem vil det derfor legges stor vekt på tilrettelegging
-                            for geointegrasjon. I skrivende stund er det ennå ikke bestemt hvilket kartsystem den nye
-                            organisasjonen satser på å ta i bruk.
-                        </requirementText>
+                        <requirementText>Det er særlig viktig for den nye organisasjonen at det legges til rette for å kunne hente oppdatert kartinformasjon og registerinformasjon (Matrikkelen) inn i sakssystemet. I valg av nytt sakssystem vil det derfor legges stor vekt på tilrettelegging for geointegrasjon. I skrivende stund er det ennå ikke bestemt hvilket kartsystem den nye organisasjonen satser på å ta i bruk. </requirementText>
                         <priority>O (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Sak-arkivløsningen skal støtte siste versjon av Geointegrasjonstandarden
-                            (Plandialog).
-                        </requirementText>
+                        <requirementText>Sak-arkivløsningen skal støtte siste versjon av Geointegrasjonstandarden (Plandialog). </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Løsningen skal blant annet gi mulighet for: 1) Kontroll av oppgitt adresse i
-                            Matrikkelen, 2) Starte kartsystem og vise aktuell arealplan 3) Hente hjemmelshaver til sak –
-                            arkiv for eiendommer innenfor et planområde eller annet digitalisert område i kartsystemet
-                            4) Starte kartsystem og vise aktuell eiendom . OBS. Listen er ikke uttømmende.
-                        </requirementText>
+                        <requirementText>Løsningen skal blant annet gi mulighet for: 1) Kontroll av oppgitt adresse i Matrikkelen, 2) Starte kartsystem og vise aktuell arealplan 3) Hente hjemmelshaver til sak – arkiv for eiendommer innenfor et planområde eller annet digitalisert område i kartsystemet 4) Starte kartsystem og vise aktuell eiendom . OBS. Listen er ikke uttømmende. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>Løsningen skal legge til rette for geointegrasjon mot oppmålingssaker.
-                            (Oppmålingsdialog)
-                        </requirementText>
+                        <requirementText>Løsningen skal legge til rette for geointegrasjon mot oppmålingssaker. (Oppmålingsdialog) </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Det skal redegjøres for mulig geointegrasjon mot byggesaker (Byggesaksdialog)
-                        </requirementText>
+                        <requirementText>Det skal redegjøres for mulig geointegrasjon mot byggesaker (Byggesaksdialog) </requirementText>
                         <priority>1 (i)</priority>
                     </requirement>
                 </requirements>
@@ -6465,130 +4601,93 @@
                 <sectionOrder>1</sectionOrder>
                 <sectionTitle>Krav til skanning</sectionTitle>
                 <description>Det vil fortsatt være behov å skanne materiale for journalføring.</description>
-                <explanation>En del materiale vil fortsatt være på papir framover og det vil være behov for å kunne
-                    skanne inn slik materiale.
-                </explanation>
-                <consequence>Hvis disse kravene oppfylles ikke, vil arkivløsningen være en hinder for å oppnå god
-                    dokumentfangst fra ikke-elektroniske kilder.
-                </consequence>
+                <explanation>En del materiale vil fortsatt være på papir framover og det vil være behov for å kunne skanne inn slik materiale. </explanation>
+                <consequence>Hvis disse kravene oppfylles ikke, vil arkivløsningen være en hinder for å oppnå god dokumentfangst fra ikke-elektroniske kilder. </consequence>
                 <type>submenu</type>
                 <showMe>true</showMe>
                 <requirements>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Leverandøren skal ta det totale ansvaret for at den tilbudte skannerløsningen
-                            (programvare og oppsett) fungerer sammen med tilbudt sak- og arkivløsning.
-                        </requirementText>
+                        <requirementText>Leverandøren skal ta det totale ansvaret for at den tilbudte skannerløsningen (programvare og oppsett) fungerer sammen med tilbudt sak- og arkivløsning. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Det skal være mulig å skanne inn dokumenter enkeltvis og deretter importere
-                            disse som en egen journalpost, eller som vedlegg til eksisterende journalpost.
-                        </requirementText>
+                        <requirementText>Det skal være mulig å skanne inn dokumenter enkeltvis og deretter importere disse som en egen journalpost, eller som vedlegg til eksisterende journalpost. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>Det skal være mulighet for bunkeskanning og direkte knytting av dokumenter til
-                            riktig journalpost f.eks. v.h.a. strekkoder. Leverandøren må beskrive hvilke krav til utstyr
-                            (printere, etiketter ol.) som finnes for at strekkoder skal kunne leses av løsningen.
-                        </requirementText>
+                        <requirementText>Det skal være mulighet for bunkeskanning og direkte knytting av dokumenter til riktig journalpost f.eks. v.h.a. strekkoder. Leverandøren må beskrive hvilke krav til utstyr (printere, etiketter ol.) som finnes for at strekkoder skal kunne leses av løsningen. </requirementText>
                         <priority>O (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>Skannerløsningen skal håndtere skanning av både ensidige og dobbeltsidige
-                            dokumenter.
-                        </requirementText>
+                        <requirementText>Skannerløsningen skal håndtere skanning av både ensidige og dobbeltsidige dokumenter. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Skannerløsningen skal håndtere skanning av minimum følgende formater; A3, A4,
-                            A5.
-                        </requirementText>
+                        <requirementText>Skannerløsningen skal håndtere skanning av minimum følgende formater; A3, A4, A5. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>6</showOrder>
-                        <requirementText>Skannerløsningen skal håndtere dokumenter med og uten farge, og dokumenter med
-                            bakgrunnsfarge og vannmerker.
-                        </requirementText>
+                        <requirementText>Skannerløsningen skal håndtere dokumenter med og uten farge, og dokumenter med bakgrunnsfarge og vannmerker. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>7</showOrder>
-                        <requirementText>Skannerløsningen skal automatisk velge å skanne til farger eller sort/hvitt
-                            basert på originaldokumentet.
-                        </requirementText>
+                        <requirementText>Skannerløsningen skal automatisk velge å skanne til farger eller sort/hvitt basert på originaldokumentet. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>8</showOrder>
-                        <requirementText>Skannerløsningen skal ha funksjonalitet som sikrer at skannede
-                            originaldokumenter ikke kan redigeres.
-                        </requirementText>
+                        <requirementText>Skannerløsningen skal ha funksjonalitet som sikrer at skannede originaldokumenter ikke kan redigeres. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>9</showOrder>
-                        <requirementText>Skannerløsningen skal tilby OCR-tolking av dokumenter som del av skanningen.
-                        </requirementText>
+                        <requirementText>Skannerløsningen skal tilby OCR-tolking av dokumenter som del av skanningen. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>10</showOrder>
-                        <requirementText>Tilbudt løsning skal ha mulighet for å omforme teksten i innskannede dokumenter
-                            til maskinredigerbar form ved hjelp av OCR-tolking av den innskannede teksten. Primært
-                            ønsker kunden at systemet skal støtte OCR-tolking i ettertid, når det er aktuelt å gjenbruke
-                            (deler av) teksten i et nytt dokument.
-                        </requirementText>
+                        <requirementText>Tilbudt løsning skal ha mulighet for å omforme teksten i innskannede dokumenter til maskinredigerbar form ved hjelp av OCR-tolking av den innskannede teksten. Primært ønsker kunden at systemet skal støtte OCR-tolking i ettertid, når det er aktuelt å gjenbruke (deler av) teksten i et nytt dokument. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>11</showOrder>
-                        <requirementText>Skannerløsningen skal til enhver tid skanne dokumentene til godkjent
-                            arkivformat.
-                        </requirementText>
+                        <requirementText>Skannerløsningen skal til enhver tid skanne dokumentene til godkjent arkivformat. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>12</showOrder>
-                        <requirementText>For saksbehandlere som tar utskrift av skannet dokument skal det fremgå av
-                            utskriften hvilken arkivsak og journalnummer dokumentet tilhører.
-                        </requirementText>
+                        <requirementText>For saksbehandlere som tar utskrift av skannet dokument skal det fremgå av utskriften hvilken arkivsak og journalnummer dokumentet tilhører. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>13</showOrder>
-                        <requirementText>Løsningen skal støtte bruk av et utvalg av de mest brukte skannerprogramvarer.
-                            Leverandøren skal beskrive lisensbetingelser og eventuell andre økonomiske betingelser.
-                        </requirementText>
+                        <requirementText>Løsningen skal støtte bruk av et utvalg av de mest brukte skannerprogramvarer. Leverandøren skal beskrive lisensbetingelser og eventuell andre økonomiske betingelser. </requirementText>
                         <priority>O (i)</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>14</showOrder>
-                        <requirementText>Organisasjonen legger opp til sentralt postmottak. Leverandøren skal beskrive
-                            hvilket utstyr og oppsett som anbefales for å sørge for at tilbudt skannerløsning fungerer
-                            optimalt. Eventuelle absolutte minstekrav skal også beskrives. Leverandøren skal komme med
-                            anbefaling til bla; 1) Skannere, 2) Oppsett av skannere og skannerprogramvare i nettverk /
-                            infrastrukturen
-                        </requirementText>
+                        <requirementText>Organisasjonen legger opp til sentralt postmottak. Leverandøren skal beskrive hvilket utstyr og oppsett som anbefales for å sørge for at tilbudt skannerløsning fungerer optimalt. Eventuelle absolutte minstekrav skal også beskrives. Leverandøren skal komme med anbefaling til bla; 1) Skannere, 2) Oppsett av skannere og skannerprogramvare i nettverk / infrastrukturen </requirementText>
                         <priority>O (i)</priority>
                     </requirement>
                 </requirements>
@@ -6600,64 +4699,46 @@
             <section>
                 <sectionOrder>1</sectionOrder>
                 <sectionTitle>Krav til konvertering</sectionTitle>
-                <description>Dette er krav som ikke er en del av standarden men som ansees å være nødvendig for å sikre
-                    god effektivitet for konvertering.
-                </description>
+                <description>Dette er krav som ikke er en del av standarden men som ansees å være nødvendig for å sikre god effektivitet for konvertering. </description>
                 <explanation>Det er viktig å kunne håndtere eldre materiale i den nye løsningen.</explanation>
-                <consequence>Dersom disse kravene ikke etterfølges kan det bli vanskelig å finne fram i historisk
-                    materialet og det kan påløpe store kostnader knyttet til uttrekk.
-                </consequence>
+                <consequence>Dersom disse kravene ikke etterfølges kan det bli vanskelig å finne fram i historisk materialet og det kan påløpe store kostnader knyttet til uttrekk. </consequence>
                 <type>submenu</type>
                 <showMe>true</showMe>
                 <requirements>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>1</showOrder>
-                        <requirementText>Alle metadata fra de aktive databasene og de historiske databasene i
-                            eksisterende journalsystem skal konverteres til valgt løsning, uten tap av data og struktur.
-                            Dette gjelder for alle de tre kommuners databaser.
-                        </requirementText>
+                        <requirementText>Alle metadata fra de aktive databasene og de historiske databasene i eksisterende journalsystem skal konverteres til valgt løsning, uten tap av data og struktur. Dette gjelder for alle de tre kommuners databaser. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>2</showOrder>
-                        <requirementText>Alle dokumenter fra aktive databaser og historiske baser skal konverteres over
-                            i ny løsning og enkelt tilgjengeliggjøres for saksbehandlerne.
-                        </requirementText>
+                        <requirementText>Alle dokumenter fra aktive databaser og historiske baser skal konverteres over i ny løsning og enkelt tilgjengeliggjøres for saksbehandlerne. </requirementText>
                         <priority>1</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>3</showOrder>
-                        <requirementText>De dokumentene som ikke er lagret i godkjent arkivformat skal konverteres til
-                            godkjent arkivformat.
-                        </requirementText>
+                        <requirementText>De dokumentene som ikke er lagret i godkjent arkivformat skal konverteres til godkjent arkivformat. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>4</showOrder>
-                        <requirementText>De historiske basene skal være lukket for registreringer, men det skal være
-                            mulighet for søking og uttak av rapporter.
-                        </requirementText>
+                        <requirementText>De historiske basene skal være lukket for registreringer, men det skal være mulighet for søking og uttak av rapporter. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>5</showOrder>
-                        <requirementText>Det skal være mulig for nye brukere (brukere tilsatt etter at konvertering er
-                            foretatt) å gis tilgang til de historiske basene.
-                        </requirementText>
+                        <requirementText>Det skal være mulig for nye brukere (brukere tilsatt etter at konvertering er foretatt) å gis tilgang til de historiske basene. </requirementText>
                         <priority>O</priority>
                     </requirement>
                     <requirement>
                         <noarkRequirement>false</noarkRequirement>
                         <showOrder>6</showOrder>
-                        <requirementText>Leverandøren skal utarbeide en plan for konverteringen, samt rapporter,
-                            sjekklister, skjemaer og andre nødvendig dokumenter for å sikre kontroll med konverteringen.
-                            Planen skal godkjennes av kunden innen konvertering påbegynnes.
-                        </requirementText>
+                        <requirementText>Leverandøren skal utarbeide en plan for konverteringen, samt rapporter, sjekklister, skjemaer og andre nødvendig dokumenter for å sikre kontroll med konverteringen. Planen skal godkjennes av kunden innen konvertering påbegynnes. </requirementText>
                         <priority>O</priority>
                     </requirement>
                 </requirements>

--- a/src/main/resources/templates/noark5.xml
+++ b/src/main/resources/templates/noark5.xml
@@ -29,31 +29,7 @@
             <section>
                 <sectionTitle>Sentrale hensyn</sectionTitle>
                 <sectionOrder>2</sectionOrder>
-                <description>For ORG_NAVN er det svært viktig at den løsningen som velges har en funksjonalitet som
-                    støtter opp om kommunens kommende arbeidsprosesser, og at brukergrensesnittet er utformet på en måte
-                    som fremmer bruk av systemet i tråd med lovpålagte krav og kommunens egne regler og rutiner. Det er
-                    et overordnet mål at all saksbehandling i ORG_NAVN skal kunne foregå fullelektronisk. Ny sak- og
-                    arkivløsning skal håndtere all saksbehandling fullelektronisk slik at man ikke blir tvunget til å
-                    opprettholde papirarkiv pga. begrensninger i løsningen. Jf. forskrift om offentlege arkiv § 2-9 om
-                    elektronisk journalføring gjelder følgende « For elektronisk journalføring skal offentlege organ
-                    normalt nytte eit arkivsystem som følgjer krava i Noark-standarden. Nye system skal vere godkjende
-                    av Riksarkivaren før dei blir tekne i bruk.» Ny systemløsning må være i henhold til
-                    NOARK5-standarden, og skal ha endelig godkjenning av Riksarkivaren. ORG_NAVN vil gjennom anskaffelse
-                    av nytt sak- og arkivsystem også tilstrebe at så høy andel som mulig av den arkivverdige
-                    dokumentproduksjonen fanges opp og arkiveres i sak- og arkivsystemet. Leverandøren må derfor tilby
-                    et produkt hvor løsninger og brukergrensesnittet mot den alminnelige saksbehandler er på et slikt
-                    nivå at lojalitet til valgt løsning blir best mulig. Fullverdig og komplett integrasjon mot
-                    e-postklient som muliggjør direkte saksbehandling og arkivering er en forutsetning. I tillegg til
-                    disse momentene vil det være særdeles viktig for Kunden hvordan system- løsningen tilrettelegger for
-                    integrasjon med fagsystemer og andre eksterne systemer. Siden ORG_NAVN er under etablering vil
-                    organisjonens IKT-portefølje være under utvikling. Leverandør må derfor ta høyde for forventninger
-                    om integrasjonsmuligheter for fagsystemer som pr dato ikke er valgt. Valgt systemløsning skal ved
-                    driftssetting ha integrasjon mot sentrale løsninger som e-post, tekstbehandler, internettportal,
-                    kartløsning etc. Valgt løsning skal legge til rette for at organisjonens nye fagsystemer så enkelt
-                    som mulig kan integreres med denne, og at man oppnår elektronisk kommunikasjon mellom sak- og
-                    arkivløsning og fagsystem som sikrer at dokumentasjon fra fagsystemene kan arkiveres og gjenfinnes i
-                    NOARK5-kjernen.
-                </description>
+                <description>For ORG_NAVN er det svært viktig at den løsningen som velges har en funksjonalitet som støtter opp om kommunens kommende arbeidsprosesser, og at brukergrensesnittet er utformet på en måte som fremmer bruk av systemet i tråd med lovpålagte krav og kommunens egne regler og rutiner. Det er et overordnet mål at all saksbehandling i ORG_NAVN skal kunne foregå fullelektronisk. Ny sak- og arkivløsning skal håndtere all saksbehandling fullelektronisk slik at man ikke blir tvunget til å opprettholde papirarkiv pga. begrensninger i løsningen. Jf. forskrift om offentlege arkiv § 2-9 om elektronisk journalføring gjelder følgende « For elektronisk journalføring skal offentlege organ normalt nytte eit arkivsystem som følgjer krava i Noark-standarden. Nye system skal vere godkjende av Riksarkivaren før dei blir tekne i bruk.» Ny systemløsning må være i henhold til NOARK5-standarden, og skal ha endelig godkjenning av Riksarkivaren. ORG_NAVN vil gjennom anskaffelse av nytt sak- og arkivsystem også tilstrebe at så høy andel som mulig av den arkivverdige dokumentproduksjonen fanges opp og arkiveres i sak- og arkivsystemet. Leverandøren må derfor tilby et produkt hvor løsninger og brukergrensesnittet mot den alminnelige saksbehandler er på et slikt nivå at lojalitet til valgt løsning blir best mulig. Fullverdig og komplett integrasjon mot e-postklient som muliggjør direkte saksbehandling og arkivering er en forutsetning. I tillegg til disse momentene vil det være særdeles viktig for Kunden hvordan system- løsningen tilrettelegger for integrasjon med fagsystemer og andre eksterne systemer. Siden ORG_NAVN er under etablering vil organisjonens IKT-portefølje være under utvikling. Leverandør må derfor ta høyde for forventninger om integrasjonsmuligheter for fagsystemer som pr dato ikke er valgt. Valgt systemløsning skal ved driftssetting ha integrasjon mot sentrale løsninger som e-post, tekstbehandler, internettportal, kartløsning etc. Valgt løsning skal legge til rette for at organisjonens nye fagsystemer så enkelt som mulig kan integreres med denne, og at man oppnår elektronisk kommunikasjon mellom sak- og arkivløsning og fagsystem som sikrer at dokumentasjon fra fagsystemene kan arkiveres og gjenfinnes i NOARK5-kjernen. </description>
                 <showMe>false</showMe>
             </section>
         </chapter>
@@ -70,27 +46,7 @@
             <section>
                 <sectionTitle>Om utfylling av tabellene</sectionTitle>
                 <sectionOrder>2</sectionOrder>
-                <description>Nedenfor er en kort beskrivelse av hensikten med kolonnene i tabellene, og hvordan
-                    kravtabellene skal fylles ut. Kolonnen «Pri» (prioritet): Angir Kunden sin prioritering av kravene.
-                    O= Obligatorisk, 1 = Svært viktig for oppdragsgiver, 2= Viktig for oppdragsgiver Obligatoriske krav
-                    skal tilfredsstilles. Manglende tilfredsstillelse av disse eller forbehold knyttet til disse vil
-                    kunne regnes som vesentlige forbehold/vesentlig avvik og kan medføre avvisning av tilbudet. Krav
-                    merket med 1 eller 2 er viktige og det forventes at disse tilfredsstilles. Hvis kravet ikke kan
-                    tilfredsstilles slik det er beskrevet, bes leverandøren kommentere hvordan dette behovet kan
-                    ivaretas i løsningen på andre måter. I tillegg er det i denne kolonnen noen krav som er markert med
-                    (i). Dette betyr at leverandøren bes gi utfyllende informasjon/beskrive. Denne informasjonen inngår
-                    som del av vurderingen av leverandørens oppfyllelse av kundens krav og formål med anskaffelsen.
-                    Kolonnen «Svar»: Her skal tilbyder svare i henhold til oppsettet nedenfor. OBS SETT INN TABELL
-                    HER!!! NB! Kategorier J-C og J-D Dersom ikke annet er angitt forplikter leverandøren seg til at
-                    tilpasning/utvikling inngår i standard-produktet. Kolonnen «Ref» (referanse): Her skal det refereres
-                    til det punkt i løsningsbeskrivelsen hvor svaret utdypes. Løsningsbeskrivelsen vil være sentral når
-                    det gjelder å sammenligne tilbud der det er svart «Ja» på at leverandør kan tilfredsstille kravet.
-                    Til en del av tabellene er det også tatt inn en formålsbeskrivelse. Disse gir viktige føringer for
-                    løsning på/håndtering av tilhørende krav, og leverandørens svar vil bli vurdert opp imot disse.
-                    Leverandøren skal til hver av tabellene også vurdere om basisløsningen de tilbyr inneholder annen
-                    funksjonalitet som støtter opp under formålet, men som ikke eksplisitt er stilt opp som et krav.
-                    Dette kommenteres særskilt. OBS SETT INN TABELL HER!!!
-                </description>
+                <description>Nedenfor er en kort beskrivelse av hensikten med kolonnene i tabellene, og hvordan kravtabellene skal fylles ut. Kolonnen «Pri» (prioritet): Angir Kunden sin prioritering av kravene. O= Obligatorisk, 1 = Svært viktig for oppdragsgiver, 2= Viktig for oppdragsgiver Obligatoriske krav skal tilfredsstilles. Manglende tilfredsstillelse av disse eller forbehold knyttet til disse vil kunne regnes som vesentlige forbehold/vesentlig avvik og kan medføre avvisning av tilbudet. Krav merket med 1 eller 2 er viktige og det forventes at disse tilfredsstilles. Hvis kravet ikke kan tilfredsstilles slik det er beskrevet, bes leverandøren kommentere hvordan dette behovet kan ivaretas i løsningen på andre måter. I tillegg er det i denne kolonnen noen krav som er markert med (i). Dette betyr at leverandøren bes gi utfyllende informasjon/beskrive. Denne informasjonen inngår som del av vurderingen av leverandørens oppfyllelse av kundens krav og formål med anskaffelsen. Kolonnen «Svar»: Her skal tilbyder svare i henhold til oppsettet nedenfor. OBS SETT INN TABELL HER!!! NB! Kategorier J-C og J-D Dersom ikke annet er angitt forplikter leverandøren seg til at tilpasning/utvikling inngår i standard-produktet. Kolonnen «Ref» (referanse): Her skal det refereres til det punkt i løsningsbeskrivelsen hvor svaret utdypes. Løsningsbeskrivelsen vil være sentral når det gjelder å sammenligne tilbud der det er svart «Ja» på at leverandør kan tilfredsstille kravet. Til en del av tabellene er det også tatt inn en formålsbeskrivelse. Disse gir viktige føringer for løsning på/håndtering av tilhørende krav, og leverandørens svar vil bli vurdert opp imot disse. Leverandøren skal til hver av tabellene også vurdere om basisløsningen de tilbyr inneholder annen funksjonalitet som støtter opp under formålet, men som ikke eksplisitt er stilt opp som et krav. Dette kommenteres særskilt. OBS SETT INN TABELL HER!!! </description>
                 <showMe>false</showMe>
             </section>
         </chapter>

--- a/src/main/test/resources/application.yml
+++ b/src/main/test/resources/application.yml
@@ -44,3 +44,9 @@ security:
 
 storage:
   location: /tmp
+
+# To add an additional format, make sure pandoc can convert from docbook to that format.
+# Grouse uses the following command to convert to odt
+# asciidoctor --backend docbook --out-file - file.adoc | pandoc --from docbook --to odt --output file.odt
+supported:
+  formats: "{ 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' : 'docx', 'application/vnd.oasis.opendocument.text': 'odt', 'text/html': 'html', 'application/pdf': 'pdf', 'application/rtf': 'rtf', 'text/asciidoc': 'adoc', 'text/markdown': 'md' }"


### PR DESCRIPTION
Swap out the old approach that could only generate a word document with a asciidoc/pandoc combination that allows the user choose between multiple formats.